### PR TITLE
Add backend and smart contract scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Features
 AI Agent Component: Reusable and intelligent.
 Decentralized Storage: Uses IPFS for model files.
 React Framework: Built with Create React App.
+Backend Service: Express server with WebSocket streams in `backend/`.
+Smart Contracts: Hardhat workspace with example contracts in `contracts/`.
 Installation
 Clone the repository:
 bash
@@ -25,6 +27,22 @@ bash
 Copy code
 npm start
 Open http://localhost:3000 in your browser to view the app.
+
+Backend
+Install dependencies and start the backend server:
+```bash
+cd backend
+npm install
+npm start
+```
+
+Contracts
+The `contracts/` folder contains a Hardhat workspace. Compile the contracts with:
+```bash
+cd contracts
+npm install
+npx hardhat compile
+```
 Scripts
 npm start: Runs the app in development mode.
 npm test: Launches the test runner.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ethers": "^5.7.2",
+    "ws": "^8.13.0",
+    "dotenv": "^16.0.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import dotenv from 'dotenv';
+
+import deployExecutor from './routes/deployExecutor';
+import abiRoute from './routes/abi';
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+app.use('/deploy-executor', deployExecutor);
+app.use('/abi', abiRoute);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Backend server listening on ${port}`);
+});

--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -1,0 +1,4 @@
+export function generateStrategyMetadata() {
+  // placeholder logic for generating strategy metadata
+  return {};
+}

--- a/backend/src/modules/mintStrategyOnChain.ts
+++ b/backend/src/modules/mintStrategyOnChain.ts
@@ -1,0 +1,4 @@
+export function mintStrategyOnChain() {
+  // placeholder logic to mint strategy on-chain
+  return {};
+}

--- a/backend/src/modules/scanDiscrepancy.ts
+++ b/backend/src/modules/scanDiscrepancy.ts
@@ -1,0 +1,4 @@
+export function scanDiscrepancy() {
+  // placeholder logic to scan for price discrepancies
+  return {};
+}

--- a/backend/src/modules/scanUniswapReserves.ts
+++ b/backend/src/modules/scanUniswapReserves.ts
@@ -1,0 +1,4 @@
+export function scanUniswapReserves() {
+  // placeholder logic for scanning Uniswap reserves
+  return {};
+}

--- a/backend/src/routes/abi.ts
+++ b/backend/src/routes/abi.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/:name', (req, res) => {
+  const { name } = req.params;
+  // placeholder to fetch ABI by name
+  res.json({ abi: name });
+});
+
+export default router;

--- a/backend/src/routes/deployExecutor.ts
+++ b/backend/src/routes/deployExecutor.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/', (_req, res) => {
+  // placeholder for deploying executor
+  res.json({ status: 'executor deployed' });
+});
+
+export default router;

--- a/backend/ws/arbitrageMatrixServer.ts
+++ b/backend/ws/arbitrageMatrixServer.ts
@@ -1,0 +1,10 @@
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ port: 8081 });
+
+wss.on('connection', ws => {
+  // placeholder stream of arbitrage matrix
+  ws.send(JSON.stringify({ matrix: [] }));
+});
+
+console.log('Arbitrage matrix WebSocket server running on port 8081');

--- a/backend/ws/server.ts
+++ b/backend/ws/server.ts
@@ -1,0 +1,9 @@
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ port: 8080 });
+
+wss.on('connection', ws => {
+  ws.send('connected');
+});
+
+console.log('WebSocket server running on port 8080');

--- a/contracts/contracts/ArbCloneFactory.sol
+++ b/contracts/contracts/ArbCloneFactory.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ArbCloneFactory {
+    event CloneCreated(address clone);
+
+    function createClone(address implementation) external returns (address) {
+        emit CloneCreated(implementation);
+        return implementation;
+    }
+}

--- a/contracts/contracts/ProxyArbExecutor.sol
+++ b/contracts/contracts/ProxyArbExecutor.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ProxyArbExecutor {
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function execute() external {
+        // placeholder for execution logic
+    }
+}

--- a/contracts/contracts/StrategyRegistry.sol
+++ b/contracts/contracts/StrategyRegistry.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract StrategyRegistry {
+    mapping(uint256 => address) public strategies;
+
+    function register(uint256 id, address strategy) external {
+        strategies[id] = strategy;
+    }
+}

--- a/contracts/contracts/mocks/MockToken.sol
+++ b/contracts/contracts/mocks/MockToken.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockToken {
+    string public name = 'MockToken';
+    string public symbol = 'MCK';
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,0 +1,14 @@
+import { HardhatUserConfig } from 'hardhat/config';
+import '@nomicfoundation/hardhat-toolbox';
+
+const config: HardhatUserConfig = {
+  solidity: '0.8.20',
+  paths: {
+    sources: './contracts',
+    tests: './test',
+    cache: './cache',
+    artifacts: './artifacts'
+  }
+};
+
+export default config;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "contracts",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "hardhat compile",
+    "deploy": "hardhat run scripts/deploy.ts",
+    "export-abis": "ts-node scripts/export-abis.ts"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "hardhat": "^2.20.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -1,0 +1,13 @@
+import { ethers } from 'hardhat';
+
+async function main() {
+  const Registry = await ethers.getContractFactory('StrategyRegistry');
+  const registry = await Registry.deploy();
+  await registry.deployed();
+  console.log(`StrategyRegistry deployed to ${registry.address}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/scripts/export-abis.ts
+++ b/contracts/scripts/export-abis.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
+async function main() {
+  const artifactsPath = path.join(__dirname, '..', 'artifacts');
+  if (!fs.existsSync(artifactsPath)) {
+    console.error('artifacts directory not found');
+    return;
+  }
+  console.log('Exporting ABIs...');
+  // placeholder for exporting logic
+}
+
+main();


### PR DESCRIPTION
## Summary
- scaffold Express backend with websocket stream modules
- add Hardhat smart contract workspace and example contracts
- document backend and contract usage in README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688d87dae718832aa1b3551537abcd52