### PR TITLE
feat: add metaverse token and governance scaffolding

### DIFF
--- a/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
+++ b/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/// @notice Placeholder for faction deployment factory.
+contract GenesisBlockFactory is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize() public initializer {
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+}
+

--- a/contracts/contracts/metaverse/governance/CrossFactionHub.sol
+++ b/contracts/contracts/metaverse/governance/CrossFactionHub.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/// @notice Placeholder for cross-faction governance hub.
+contract CrossFactionHub is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize() public initializer {
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+}
+

--- a/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
+++ b/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+interface IFunctionalToken {
+    function mint(address to, uint256 id, uint256 amount, bytes calldata data) external;
+}
+
+/**
+ * @title HouseOfTheLaw
+ * @notice Manages task validation, quadratic proposal voting and reward issuance.
+ */
+contract HouseOfTheLaw is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
+    bytes32 public constant VALIDATOR_ROLE = keccak256("VALIDATOR_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    struct Proposal {
+        address proposer;
+        string description;
+        uint256 voteTally;
+        bool executed;
+    }
+
+    IFunctionalToken public functionalToken;
+
+    // Governance token balances (non-transferable)
+    mapping(address => uint256) public governanceBalance;
+    uint256 public totalGT;
+
+    // Parameters for FT minting based on GT supply (in basis points)
+    uint256 public alpha; // e.g., 10000 = 100%
+    uint256 public reserveRatio; // e.g., 2000 = 20%
+
+    // Proposals
+    uint256 public proposalCount;
+    mapping(uint256 => Proposal) public proposals;
+    mapping(uint256 => mapping(address => uint256)) public votesCast; // number of votes already cast per user
+
+    event TaskValidated(address indexed user, uint256 indexed taskId, uint256 ftId, uint256 ftAmount, uint256 gtReward);
+    event ProposalCreated(uint256 indexed proposalId, address indexed proposer, string description);
+    event Voted(uint256 indexed proposalId, address indexed voter, uint256 votes, uint256 cost);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address functionalToken_, uint256 alphaBps_, uint256 reserveRatioBps_) public initializer {
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        require(reserveRatioBps_ <= 10_000, "reserve too high");
+        functionalToken = IFunctionalToken(functionalToken_);
+        alpha = alphaBps_;
+        reserveRatio = reserveRatioBps_;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(VALIDATOR_ROLE, msg.sender);
+        _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    /**
+     * @notice Validates a task for `user`, rewards GT and mints FTs based on current supply.
+     */
+    function validateTask(address user, uint256 taskId, uint256 ftId, uint256 gtReward) external onlyRole(VALIDATOR_ROLE) {
+        // update governance balance
+        governanceBalance[user] += gtReward;
+        totalGT += gtReward;
+
+        // compute FT mint amount
+        uint256 ftAmount = (totalGT * alpha * (10_000 - reserveRatio)) / 10_000 / 10_000;
+        functionalToken.mint(user, ftId, ftAmount, "");
+
+        emit TaskValidated(user, taskId, ftId, ftAmount, gtReward);
+    }
+
+    /**
+     * @notice Create a new proposal.
+     */
+    function createProposal(string calldata description) external returns (uint256 proposalId) {
+        proposalId = ++proposalCount;
+        proposals[proposalId] = Proposal({
+            proposer: msg.sender,
+            description: description,
+            voteTally: 0,
+            executed: false
+        });
+        emit ProposalCreated(proposalId, msg.sender, description);
+    }
+
+    /**
+     * @notice Quadratic voting on a proposal. Costs GT squared.
+     */
+    function vote(uint256 proposalId, uint256 votes) external {
+        Proposal storage p = proposals[proposalId];
+        require(bytes(p.description).length != 0, "invalid proposal");
+
+        uint256 newVotes = votesCast[proposalId][msg.sender] + votes;
+        uint256 cost = newVotes * newVotes - votesCast[proposalId][msg.sender] * votesCast[proposalId][msg.sender];
+        require(governanceBalance[msg.sender] >= cost, "insufficient GT");
+
+        governanceBalance[msg.sender] -= cost;
+        votesCast[proposalId][msg.sender] = newVotes;
+        p.voteTally += votes;
+
+        emit Voted(proposalId, msg.sender, votes, cost);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+}
+

--- a/contracts/contracts/metaverse/registry/MpNSRegistry.sol
+++ b/contracts/contracts/metaverse/registry/MpNSRegistry.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/// @notice Placeholder for Metaverse Naming Service registry.
+contract MpNSRegistry is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
+    bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize() public initializer {
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(REGISTRAR_ROLE, msg.sender);
+        _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+}
+

--- a/contracts/contracts/metaverse/tokens/FunctionalToken.sol
+++ b/contracts/contracts/metaverse/tokens/FunctionalToken.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC1155Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @title FunctionalToken
+ * @notice ERC-1155 token for both fungible utility tokens and non-fungible educational milestones.
+ *         Utilises UUPS upgradeability and role based access control.
+ */
+contract FunctionalToken is Initializable, ERC1155Upgradeable, AccessControlUpgradeable, UUPSUpgradeable {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(string memory uri_) public initializer {
+        __ERC1155_init(uri_);
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(MINTER_ROLE, msg.sender);
+        _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    /**
+     * @notice Mint a single token type to an address.
+     */
+    function mint(address to, uint256 id, uint256 amount, bytes calldata data) external onlyRole(MINTER_ROLE) {
+        _mint(to, id, amount, data);
+    }
+
+    /**
+     * @notice Gas optimised batch reward minting. Mints the same token id and amount to multiple recipients.
+     */
+    function batchRewardMint(address[] calldata recipients, uint256 id, uint256 amount, bytes calldata data) external onlyRole(MINTER_ROLE) {
+        uint256 length = recipients.length;
+        for (uint256 i; i < length; ) {
+            _mint(recipients[i], id, amount, data);
+            unchecked { ++i; }
+        }
+    }
+
+    /**
+     * @notice Convenience function to fetch balances for multiple token ids.
+     */
+    function balancesOf(address account, uint256[] calldata ids) external view returns (uint256[] memory balances) {
+        uint256 length = ids.length;
+        balances = new uint256[](length);
+        for (uint256 i; i < length; ) {
+            balances[i] = balanceOf(account, ids[i]);
+            unchecked { ++i; }
+        }
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+}
+

--- a/contracts/contracts/metaverse/validation/ProofOfObservation.sol
+++ b/contracts/contracts/metaverse/validation/ProofOfObservation.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/// @notice Placeholder for PoO validation logic.
+contract ProofOfObservation is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
+    bytes32 public constant VALIDATOR_ROLE = keccak256("VALIDATOR_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize() public initializer {
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(VALIDATOR_ROLE, msg.sender);
+        _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+}
+

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -2,7 +2,7 @@ import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
 const config: HardhatUserConfig = {
-  solidity: '0.8.20',
+  solidity: '0.8.23',
   paths: {
     sources: './contracts',
     tests: './test',

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -2,6 +2,9 @@
   "name": "contracts",
   "version": "1.0.0",
   "private": true,
+  "dependencies": {
+    "@openzeppelin/contracts-upgradeable": "^5.0.1"
+  },
   "scripts": {
     "build": "hardhat compile",
     "deploy": "hardhat run scripts/deploy.ts",

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": ["./hardhat.config.ts", "./scripts", "./test"]
+}


### PR DESCRIPTION
## Summary
- scaffold modular metaverse contract suite with placeholders for core, registry, validation, and governance hubs
- implement upgradeable ERC-1155 FunctionalToken with role-based minting and batch reward issuance
- add HouseOfTheLaw governance contract featuring task validation, quadratic voting, and FT reward mechanics

## Testing
- `npm run build` *(fails: Couldn't download compiler version list - HH502)*

------
https://chatgpt.com/codex/tasks/task_e_689001d26118832a9b1d52d16e612ca0