### PR TITLE
feat: add staking transfer role

### DIFF
--- a/contracts/contracts/metaverse/governance/GTStaking.sol
+++ b/contracts/contracts/metaverse/governance/GTStaking.sol
@@ -31,6 +31,7 @@ contract GTStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
         __UUPSUpgradeable_init();
         gt = GovernanceToken(gt_);
         ft = FunctionalToken(ft_);
+        require(gt.hasRole(gt.STAKING_CONTRACT_ROLE(), address(this)), "missing staking role");
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(UPGRADER_ROLE, msg.sender);
     }


### PR DESCRIPTION
## Summary
- allow designated staking contract to move soulbound governance tokens
- verify staking contract role during GTStaking initialization

## Testing
- `npx hardhat compile` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68905ddaba1c832aad4c3a050d2ecb57