### PR TITLE
Add GT staking status query and unstake capability

### DIFF
--- a/contracts/contracts/metaverse/governance/GTStaking.sol
+++ b/contracts/contracts/metaverse/governance/GTStaking.sol
@@ -60,6 +60,18 @@ contract GTStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
         return 1e18; // 1 * 1e18
     }
 
+    function isStaked(address user, uint256 tokenId) external view returns (bool) {
+        return staked[user][tokenId] > 0;
+    }
+
+    function unstake(address user, uint256 tokenId) external returns (bool) {
+        uint256 amount = staked[user][tokenId];
+        require(amount > 0, "no stake");
+        staked[user][tokenId] = 0;
+        gt.stakeTransferFrom(address(this), user, tokenId, amount, "");
+        return true;
+    }
+
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
 }
 

--- a/contracts/contracts/metaverse/tokens/FunctionalToken.sol
+++ b/contracts/contracts/metaverse/tokens/FunctionalToken.sol
@@ -92,6 +92,15 @@ contract FunctionalToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
         super.safeBatchTransferFrom(from, to, ids, amounts, data);
     }
 
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC1155Upgradeable, AccessControlUpgradeable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
 }
 

--- a/contracts/contracts/metaverse/tokens/GovernanceToken.sol
+++ b/contracts/contracts/metaverse/tokens/GovernanceToken.sol
@@ -97,5 +97,14 @@ contract GovernanceToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
         return userGTs[user];
     }
 
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC1155Upgradeable, AccessControlUpgradeable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
 }


### PR DESCRIPTION
## Summary
- add `isStaked` and `unstake` helpers to `GTStaking`
- implement `supportsInterface` overrides for token contracts for compilation

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*
- `npx solcjs --base-path . --include-path node_modules --bin --abi contracts/metaverse/governance/GTStaking.sol contracts/metaverse/validation/PoO_TaslkFlow.sol`

------
https://chatgpt.com/codex/tasks/task_e_689064f79d3c832a90402ab14bd512bc