### PR TITLE
feat: validate task before mint

### DIFF
--- a/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
+++ b/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
@@ -14,12 +14,22 @@ interface IGTStaking {
     function isStaked(address user, uint256 tokenId) external view returns (bool);
 }
 
+interface IProofOfObservation {
+    function taskSubmissions(uint256 taskId)
+        external
+        view
+        returns (address user, uint256 id, string memory proof, bool validated);
+}
+
 contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     bytes32 public constant VALIDATOR_ROLE = keccak256("VALIDATOR_ROLE");
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
     IFunctionalToken public functionalToken;
     IGTStaking public gtStaking;
+    IProofOfObservation public proofOfObservation;
+
+    mapping(uint256 => bool) public rewardedTasks;
 
     event TaskRewarded(address indexed user, uint256 taskId, uint256 ftId, uint256 amount);
 
@@ -27,12 +37,13 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
         _disableInitializers();
     }
 
-    function initialize(address ftAddr, address stakingAddr) public initializer {
+    function initialize(address ftAddr, address stakingAddr, address pooAddr) public initializer {
         __AccessControl_init();
         __UUPSUpgradeable_init();
 
         functionalToken = IFunctionalToken(ftAddr);
         gtStaking = IGTStaking(stakingAddr);
+        proofOfObservation = IProofOfObservation(pooAddr);
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(VALIDATOR_ROLE, msg.sender);
@@ -47,10 +58,17 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
         uint256 ftAmount
     ) external onlyRole(VALIDATOR_ROLE) {
         require(gtStaking.isStaked(user, tokenId), "GT not staked");
+        require(!rewardedTasks[taskId], "Task already rewarded");
+
+        (address recordedUser, , , bool validated) = proofOfObservation.taskSubmissions(taskId);
+        require(validated && recordedUser == user, "Invalid task");
+
         bool unstaked = gtStaking.unstake(user, tokenId);
         require(unstaked, "Unstake failed");
 
         functionalToken.mint(user, ftId, ftAmount, "");
+
+        rewardedTasks[taskId] = true;
 
         emit TaskRewarded(user, taskId, ftId, ftAmount);
     }


### PR DESCRIPTION
## Summary
- integrate ProofOfObservation to verify task validity
- prevent double payouts by tracking rewarded task IDs

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689066d70408832a9f14429d0d481ce3