### PR TITLE
fix: provide empty bytes for functional token mint

### DIFF
--- a/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
+++ b/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
@@ -88,7 +88,7 @@ contract HouseOfTheLaw is Initializable, AccessControlUpgradeable, UUPSUpgradeab
 
         // Compute FT mint amount
         uint256 ftAmount = (totalGT * alpha * (10_000 - reserveRatio)) / 10_000 / 10_000;
-        functionalToken.mint(user, ftId, ftAmount, "");
+        functionalToken.mint(user, ftId, ftAmount, bytes(""));
 
         emit TaskValidated(user, taskId, ftId, ftAmount, gtReward);
     }

--- a/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
+++ b/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
@@ -66,7 +66,7 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
         bool unstaked = gtStaking.unstake(user, tokenId);
         require(unstaked, "Unstake failed");
 
-        functionalToken.mint(user, ftId, ftAmount, "");
+        functionalToken.mint(user, ftId, ftAmount, bytes(""));
 
         rewardedTasks[taskId] = true;
 


### PR DESCRIPTION
## Summary
- replace empty string parameter with `bytes("")` when minting functional tokens

## Testing
- `npm run build` (fails: Couldn't download compiler version list, Proxy response 403)
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68906a48abf4832a81858734787149cb