### PR TITLE
Validate staking contract address and emit role event

### DIFF
--- a/contracts/contracts/metaverse/tokens/GovernanceToken.sol
+++ b/contracts/contracts/metaverse/tokens/GovernanceToken.sol
@@ -32,6 +32,8 @@ contract GovernanceToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
         string proofURI
     );
 
+    event StakingRoleGranted(address indexed stakingContract);
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -45,7 +47,9 @@ contract GovernanceToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
         _grantRole(UPGRADER_ROLE, msg.sender);
+        require(stakingContract != address(0), "invalid staking contract");
         _grantRole(STAKING_CONTRACT_ROLE, stakingContract);
+        emit StakingRoleGranted(stakingContract);
     }
 
     /// @notice Mint a soulbound Governance Token to a user with metadata


### PR DESCRIPTION
## Summary
- add zero-address check for staking contract during initialization
- emit `StakingRoleGranted` when staking contract role is set

## Testing
- `npm test` *(fails: No tests found)*
- `npm --prefix contracts run build` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689077896f6c832abc7230532a984e80