### PR TITLE
Add storage gaps for upgradeable contracts

### DIFF
--- a/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
+++ b/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
@@ -79,4 +79,8 @@ contract GenesisBlockFaction is Initializable, AccessControlUpgradeable, UUPSUpg
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts/metaverse/governance/CrossFactionHub.sol
+++ b/contracts/contracts/metaverse/governance/CrossFactionHub.sol
@@ -140,4 +140,8 @@ contract CrossFactionHub is Initializable, UUPSUpgradeable, AccessControlUpgrade
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts/metaverse/governance/GTStaking.sol
+++ b/contracts/contracts/metaverse/governance/GTStaking.sol
@@ -79,5 +79,9 @@ contract GTStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }
 

--- a/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
+++ b/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
@@ -162,4 +162,8 @@ contract HouseOfTheLaw is Initializable, AccessControlUpgradeable, UUPSUpgradeab
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts/metaverse/registry/MpNSRegistry.sol
+++ b/contracts/contracts/metaverse/registry/MpNSRegistry.sol
@@ -133,5 +133,9 @@ contract MpNSRegistry is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }
 

--- a/contracts/contracts/metaverse/tokens/FunctionalToken.sol
+++ b/contracts/contracts/metaverse/tokens/FunctionalToken.sol
@@ -102,5 +102,9 @@ contract FunctionalToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }
 

--- a/contracts/contracts/metaverse/tokens/GovernanceToken.sol
+++ b/contracts/contracts/metaverse/tokens/GovernanceToken.sol
@@ -111,4 +111,8 @@ contract GovernanceToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
+++ b/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
@@ -74,4 +74,8 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts/metaverse/validation/ProofOfObservation.sol
+++ b/contracts/contracts/metaverse/validation/ProofOfObservation.sol
@@ -77,4 +77,8 @@ contract ProofOfObservation is Initializable, UUPSUpgradeable, AccessControlUpgr
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /// @dev Reserve storage space to allow layout changes in the future.
+    /// New variables must be appended at the end and the gap size adjusted if used.
+    uint256[50] private __gap;
 }


### PR DESCRIPTION
## Summary
- Reserve storage slots in core metaverse contracts with a `uint256[50] private __gap`
- Note that future state variables must be appended and gap reduced accordingly

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm --prefix contracts run build` *(fails: Couldn't download compiler version list, proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6891409b3b24832abc69cc5796d9518c