### PR TITLE
Require MpNS name frozen before creating faction

### DIFF
--- a/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
+++ b/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
@@ -8,6 +8,7 @@ import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/acce
 interface IMpNSRegistry {
     function ownerOf(string calldata name) external view returns (address);
     function nameToUri(string calldata name) external view returns (string memory);
+    function isFrozen(string calldata name) external view returns (bool);
 }
 
 /**
@@ -61,6 +62,8 @@ contract GenesisBlockFaction is Initializable, AccessControlUpgradeable, UUPSUpg
         require(owner == msg.sender, "Only name owner can deploy faction");
 
         string memory uri = mpns.nameToUri(name);
+
+        require(mpns.isFrozen(name), "Name must be frozen");
 
         factions[name] = Faction({
             creator: msg.sender,


### PR DESCRIPTION
## Summary
- extend IMpNSRegistry with `isFrozen`
- require frozen name before creating a faction

## Testing
- `npm --prefix contracts run build` *(fails: Couldn't download compiler version list)*
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891477705fc832ab5adb46cb36ca908