### PR TITLE
Add staking amount validation and minter role check

### DIFF
--- a/contracts/contracts/metaverse/governance/GTStaking.sol
+++ b/contracts/contracts/metaverse/governance/GTStaking.sol
@@ -35,6 +35,7 @@ contract GTStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
         gt = GovernanceToken(gt_);
         ft = FunctionalToken(ft_);
         require(gt.hasRole(gt.STAKING_CONTRACT_ROLE(), address(this)), "missing staking role");
+        require(ft.hasRole(ft.MINTER_ROLE(), address(this)), "missing minter role");
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(UPGRADER_ROLE, msg.sender);
     }
@@ -44,12 +45,14 @@ contract GTStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
     }
 
     function stake(uint256 id, uint256 amount) external {
+        require(amount > 0, "amount=0");
         gt.stakeTransferFrom(msg.sender, address(this), id, amount, "");
         staked[msg.sender][id] += amount;
         emit Staked(msg.sender, id, amount);
     }
 
     function completeTask(uint256 id, uint256 amount, uint256 taskId) external {
+        require(amount > 0, "amount=0");
         require(staked[msg.sender][id] >= amount, "insufficient stake");
         staked[msg.sender][id] -= amount;
         gt.stakeTransferFrom(address(this), msg.sender, id, amount, "");


### PR DESCRIPTION
## Summary
- ensure GTStaking contract has minter role on FunctionalToken during initialization
- validate non-zero amounts in stake and completeTask

## Testing
- `npm run build` *(fails: Couldn't download compiler version list)*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6891491f0198832a953348cd06f1a973