### PR TITLE
chore: rename PoO reward function to validateTask

### DIFF
--- a/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
+++ b/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
@@ -91,7 +91,9 @@ contract HouseOfTheLaw is Initializable, AccessControlUpgradeable, UUPSUpgradeab
         _;
     }
 
-    function rewardFromPoO(
+    /// @notice Called by ProofOfObservation after a task is validated.
+    ///         Mints the user's FT reward and credits their GT balance.
+    function validateTask(
         address user,
         uint256 taskId,
         uint256 ftId,

--- a/contracts/contracts/metaverse/governance/README-HotL-Info.md
+++ b/contracts/contracts/metaverse/governance/README-HotL-Info.md
@@ -60,8 +60,8 @@ Each proposal includes:
 
  🧰 Core Functions
 
- ✅ `rewardFromPoO(user, taskId, ftId, gtReward)`
-Issues GT to the user and mints FTs.
+ ✅ `validateTask(user, taskId, ftId, gtReward)`
+Credits GT to the user and mints corresponding FTs.
 - 🔐 Can only be called by the PoO contract
 
  🧠 `createProposal(desc, ipfsHash, eligibleGTId, target, data)`
@@ -107,7 +107,7 @@ This ensures:
 
 ```solidity
 // From PoO contract
-HouseOfTheLaw(rewarder).rewardFromPoO(user, taskId, 1, 20);
+HouseOfTheLaw(rewarder).validateTask(user, taskId, 1, 20);
 
 // From UI with console open
 house.createProposal(

--- a/contracts/contracts/metaverse/validation/ProofOfObservation.sol
+++ b/contracts/contracts/metaverse/validation/ProofOfObservation.sol
@@ -6,7 +6,13 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
 interface IHouseOfTheLaw {
-    function validateTask(address user, uint256 taskId, uint256 ftId, uint256 gtReward) external;
+    /// @notice Credits GT and mints FTs for a validated task.
+    function validateTask(
+        address user,
+        uint256 taskId,
+        uint256 ftId,
+        uint256 gtReward
+    ) external;
 }
 
 /**


### PR DESCRIPTION
## Summary
- rename `rewardFromPoO` to `validateTask` in `HouseOfTheLaw`
- document `validateTask` in `ProofOfObservation` interface
- update governance README examples for new name

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68914ad82dfc832a86c83c47c9f16b4c