### PR TITLE
feat: allow granting staking role post deployment

### DIFF
--- a/contracts/contracts/metaverse/governance/GTStaking.sol
+++ b/contracts/contracts/metaverse/governance/GTStaking.sol
@@ -34,7 +34,6 @@ contract GTStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
         __UUPSUpgradeable_init();
         gt = GovernanceToken(gt_);
         ft = FunctionalToken(ft_);
-        require(gt.hasRole(gt.STAKING_CONTRACT_ROLE(), address(this)), "missing staking role");
         require(ft.hasRole(ft.MINTER_ROLE(), address(this)), "missing minter role");
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(UPGRADER_ROLE, msg.sender);

--- a/contracts/contracts/metaverse/tokens/GovernanceToken.sol
+++ b/contracts/contracts/metaverse/tokens/GovernanceToken.sol
@@ -39,7 +39,7 @@ contract GovernanceToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
         _disableInitializers();
     }
 
-    function initialize(string memory uri_, address stakingContract) public initializer {
+    function initialize(string memory uri_) public initializer {
         __ERC1155_init(uri_);
         __AccessControl_init();
         __UUPSUpgradeable_init();
@@ -47,6 +47,12 @@ contract GovernanceToken is Initializable, ERC1155Upgradeable, AccessControlUpgr
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
         _grantRole(UPGRADER_ROLE, msg.sender);
+    }
+
+    function grantStakingRole(address stakingContract)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(stakingContract != address(0), "invalid staking contract");
         _grantRole(STAKING_CONTRACT_ROLE, stakingContract);
         emit StakingRoleGranted(stakingContract);


### PR DESCRIPTION
## Summary
- allow GovernanceToken to grant staking role post-deployment
- simplify GTStaking initialization by removing staking role check

## Testing
- `npm --prefix contracts run build` *(fails: Couldn't download compiler version list, Proxy response (403))*
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68914d0fbb98832aa5e904979fc41787