### PR TITLE
Add validation checks for PoO rewards

### DIFF
--- a/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
+++ b/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {FunctionalToken} from "../tokens/FunctionalToken.sol";
 
 interface IFunctionalToken {
     function mint(address to, uint256 id, uint256 amount, bytes calldata data) external;
@@ -99,6 +100,8 @@ contract HouseOfTheLaw is Initializable, AccessControlUpgradeable, UUPSUpgradeab
         uint256 ftId,
         uint256 gtReward
     ) external onlyPoO {
+        require(ftId >= FunctionalToken.FT_START_ID(), "invalid FT id");
+        require(gtReward > 0, "reward=0");
         governanceBalance[user] += gtReward;
         totalGT += gtReward;
 


### PR DESCRIPTION
## Summary
- add FunctionalToken import
- validate functional token IDs and governance token rewards in PoO rewards

## Testing
- `npx hardhat test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689150f01f3c832ab868c0528c2f1172