### PR TITLE
feat: add validation status helper

### DIFF
--- a/contracts/contracts/metaverse/validation/ProofOfObservation.sol
+++ b/contracts/contracts/metaverse/validation/ProofOfObservation.sol
@@ -82,6 +82,17 @@ contract ProofOfObservation is Initializable, UUPSUpgradeable, AccessControlUpgr
         emit TaskValidated(msg.sender, submission.user, taskId, gtReward);
     }
 
+    /// @notice Returns true if the user has at least one validated task submission.
+    function isValidated(address user) external view returns (bool) {
+        uint256[] storage tasks = userTasks[user];
+        for (uint256 i = 0; i < tasks.length; i++) {
+            if (taskSubmissions[user][tasks[i]].validated) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
 
     /// @dev Reserve storage space to allow layout changes in the future.


### PR DESCRIPTION
## Summary
- add `isValidated` view to verify if a user has at least one validated task

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list (HH502))*

------
https://chatgpt.com/codex/tasks/task_e_68915321ab44832aacc255c673130966