### PR TITLE
feat: allow updating governance parameters

### DIFF
--- a/contracts/contracts/test/MockAIAssistantGate.sol
+++ b/contracts/contracts/test/MockAIAssistantGate.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IAIAssistantGate {
+    function isConsoleOpen(address user) external view returns (bool);
+}
+
+contract MockAIAssistantGate is IAIAssistantGate {
+    mapping(address => bool) public open;
+
+    function setOpen(address user, bool status) external {
+        open[user] = status;
+    }
+
+    function isConsoleOpen(address user) external view returns (bool) {
+        return open[user];
+    }
+}

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -3,8 +3,25 @@ import { ethers } from 'hardhat';
 async function main() {
   const Registry = await ethers.getContractFactory('StrategyRegistry');
   const registry = await Registry.deploy();
-  await registry.deployed();
-  console.log(`StrategyRegistry deployed to ${registry.address}`);
+  await registry.waitForDeployment();
+  console.log(`StrategyRegistry deployed to ${registry.target}`);
+
+  const ALPHA_BPS = 10_000n; // 1:1 FT to GT
+  const RESERVE_RATIO_BPS = 1_000n; // 10% reserve
+
+  const House = await ethers.getContractFactory('HouseOfTheLaw');
+  const house = await House.deploy();
+  await house.waitForDeployment();
+  await house.initialize(
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ethers.ZeroAddress,
+    ALPHA_BPS,
+    RESERVE_RATIO_BPS
+  );
+  console.log(
+    `HouseOfTheLaw initialized with alpha ${ALPHA_BPS} and reserve ratio ${RESERVE_RATIO_BPS}`
+  );
 }
 
 main().catch((error) => {

--- a/contracts/test/HouseOfTheLaw.test.ts
+++ b/contracts/test/HouseOfTheLaw.test.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describe('HouseOfTheLaw parameter updates', function () {
+  async function deployFixture() {
+    const [admin, aiUser, other] = await ethers.getSigners();
+
+    const Gate = await ethers.getContractFactory('MockAIAssistantGate');
+    const gate = await Gate.deploy();
+    await gate.waitForDeployment();
+
+    const House = await ethers.getContractFactory('HouseOfTheLaw');
+    const house = await House.deploy();
+    await house.waitForDeployment();
+
+    await house.initialize(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+      gate.target,
+      10_000n,
+      1_000n
+    );
+
+    return { house, gate, admin, aiUser, other };
+  }
+
+  it('allows admin to update alpha', async function () {
+    const { house, admin } = await deployFixture();
+    await expect(house.connect(admin).setAlpha(5_000n))
+      .to.emit(house, 'AlphaUpdated')
+      .withArgs(10_000n, 5_000n, admin.address);
+    expect(await house.alpha()).to.equal(5_000n);
+  });
+
+  it('allows AI controller to update reserve ratio', async function () {
+    const { house, gate, aiUser } = await deployFixture();
+    await gate.setOpen(aiUser.address, true);
+    await expect(house.connect(aiUser).setReserveRatio(3_000n))
+      .to.emit(house, 'ReserveRatioUpdated')
+      .withArgs(1_000n, 3_000n, aiUser.address);
+    expect(await house.reserveRatio()).to.equal(3_000n);
+  });
+
+  it('reverts for unauthorized callers', async function () {
+    const { house, other } = await deployFixture();
+    await expect(house.connect(other).setAlpha(1n)).to.be.revertedWith(
+      'AI console not active'
+    );
+    await expect(
+      house.connect(other).setReserveRatio(1n)
+    ).to.be.revertedWith('AI console not active');
+  });
+
+  it('rejects reserve ratio above 10000', async function () {
+    const { house, admin } = await deployFixture();
+    await expect(
+      house.connect(admin).setReserveRatio(10_001n)
+    ).to.be.revertedWith('reserve too high');
+  });
+});


### PR DESCRIPTION
## Summary
- allow governance or AI to adjust `alpha` and `reserveRatio` in `HouseOfTheLaw`
- add events for parameter updates and dynamic config tests
- provide deploy script defaults for alpha and reserve ratio

## Testing
- `npx hardhat test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689158478490832ab4fda16838a166df