### PR TITLE
Reference config and bonding curve in staking

### DIFF
--- a/contracts/contracts/metaverse/governance/README-Stake-Info.md
+++ b/contracts/contracts/metaverse/governance/README-Stake-Info.md
@@ -63,11 +63,13 @@ Called **only by ProofOfObservation** when a task is validated.
 
 ### 📐 `calculateReward(uint256 taskId)`
 
-Applies basic demand/supply reward logic:
+Applies demand/supply logic and global configuration:
 
 * 🔺 If demand > supply → bonus FT
 * 🔻 If supply > demand → lower FT
 * ⚖️ Balanced → 1x FT
+* ⚙️ Scales using `alpha` & `reserveRatio` from `HouseOfTheLaw`
+* 📉 Bonding curve lowers rewards as total FT supply rises
 
 ---
 
@@ -102,6 +104,7 @@ User retrieves GT after task completion or cancellation.
 * `GovernanceToken.sol`: must support `stakeTransferFrom`
 * `FunctionalToken.sol`: must support `mint(to, id, amount)`
 * `ProofOfObservation.sol`: verifies work validity
+* `HouseOfTheLaw.sol`: provides `alpha` and `reserveRatio`
 
 ---
 
@@ -111,6 +114,15 @@ User retrieves GT after task completion or cancellation.
 * 📦 Batch staking for multiple GT IDs
 * 🌐 On-chain AI scoring feedback loops
 * 🛡️ Slashing penalties for false PoO attempts
+
+---
+
+## 🛠 Migration Notes
+
+* `initialize` now expects the `HouseOfTheLaw` (or config) address.
+* Rewards are influenced by `alpha`/`reserveRatio` from that contract.
+* A bonding curve tracks total FT supply—existing deployments should
+  snapshot supply before upgrading.
 
 ---
 

--- a/contracts/test/GTStaking.test.ts
+++ b/contracts/test/GTStaking.test.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describe('GTStaking rewards', function () {
+  it('references HouseOfTheLaw params and bonding curve', async function () {
+    const [deployer, user] = await ethers.getSigners();
+
+    const GT = await ethers.getContractFactory('GovernanceToken');
+    const gt = await GT.deploy();
+    await gt.waitForDeployment();
+    await gt.initialize('');
+
+    const FT = await ethers.getContractFactory('FunctionalToken');
+    const ft = await FT.deploy();
+    await ft.waitForDeployment();
+    await ft.initialize('');
+
+    const House = await ethers.getContractFactory('HouseOfTheLaw');
+    const house = await House.deploy();
+    await house.waitForDeployment();
+    await house.initialize(ft.target, gt.target, deployer.address, 1_000, 500);
+
+    const Staking = await ethers.getContractFactory('GTStaking');
+    const staking = await Staking.deploy();
+    await staking.waitForDeployment();
+
+    await gt.grantStakingRole(staking.target);
+    await ft.grantRole(await ft.MINTER_ROLE(), staking.target);
+
+    await staking.initialize(gt.target, ft.target, house.target);
+
+    await staking.setTaskMetrics(1, 1, 1);
+
+    await gt.mintGT(user.address, 0, 0, 0, '');
+    const tokenId = 1n;
+    await staking.connect(user).stake(tokenId, 1);
+
+    const reward1 = await staking.calculateReward(1);
+    expect(reward1).to.equal(1050000000000000000n);
+
+    await staking.connect(user).completeTask(tokenId, 1, 1);
+
+    const reward2 = await staking.calculateReward(1);
+    expect(reward2 < reward1).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- fetch alpha/reserveRatio from HouseOfTheLaw in GTStaking
- add bonding curve and FT supply tracking to reward math
- document new reward scaling and migration notes

## Testing
- `npx hardhat test` *(fails: HH502: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68915ceeaa5c832aa9b6e4a8fb611e56