### PR TITLE
Clarify FT reward formula and add tests

### DIFF
--- a/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
+++ b/contracts/contracts/metaverse/governance/HouseOfTheLaw.sol
@@ -127,6 +127,8 @@ contract HouseOfTheLaw is Initializable, AccessControlUpgradeable, UUPSUpgradeab
         governanceBalance[user] += gtReward;
         totalGT += gtReward;
 
+        // FT = (gtReward * alpha * (1 - reserveRatio / 10000)) / 10000
+        // Uses only this task's GT reward, independent of cumulative supply
         uint256 ftAmount = (gtReward * alpha * (10_000 - reserveRatio)) / 10_000 / 10_000;
         functionalToken.mint(user, ftId, ftAmount, "");
 

--- a/contracts/contracts/metaverse/governance/README.md
+++ b/contracts/contracts/metaverse/governance/README.md
@@ -78,7 +78,8 @@ Formula used to calculate FT reward:
 
 ```
 
-FT = (totalGT \* alpha \* (1 - reserveRatio)) / 10000²
+// GT reward from the validated task drives FT minting
+FT = (gtReward \* alpha \* (1 - reserveRatio)) / 10000²
 
 ````
 

--- a/contracts/test/HouseOfTheLaw.validateTask.test.ts
+++ b/contracts/test/HouseOfTheLaw.validateTask.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describe('HouseOfTheLaw validateTask formula', function () {
+  async function deployFixture() {
+    const [admin, poo, user1, user2] = await ethers.getSigners();
+
+    const Gate = await ethers.getContractFactory('MockAIAssistantGate');
+    const gate = await Gate.deploy();
+    await gate.waitForDeployment();
+
+    const FT = await ethers.getContractFactory('FunctionalToken');
+    const ft = await FT.deploy();
+    await ft.waitForDeployment();
+    await ft.initialize('');
+
+    const House = await ethers.getContractFactory('HouseOfTheLaw');
+    const house = await House.deploy();
+    await house.waitForDeployment();
+    const alpha = 10_000n; // 100% FT per GT
+    const reserveRatio = 2_000n; // 20% held in reserve
+    await house.initialize(ft.target, ethers.ZeroAddress, gate.target, alpha, reserveRatio);
+
+    // allow HouseOfTheLaw to mint FTs
+    const MINTER_ROLE = await ft.MINTER_ROLE();
+    await ft.grantRole(MINTER_ROLE, house.target);
+
+    // set PoO address
+    await house.setProofOfObservation(poo.address);
+
+    const ftId = await ft.FT_START_ID();
+    return { house, ft, poo, user1, user2, ftId, alpha, reserveRatio };
+  }
+
+  it('mints FTs based solely on gtReward', async function () {
+    const { house, ft, poo, user1, user2, ftId, alpha, reserveRatio } = await deployFixture();
+
+    const gtReward = 100n;
+    const expectedFt = (gtReward * alpha * (10_000n - reserveRatio)) / 10_000n / 10_000n;
+
+    await house.connect(poo).validateTask(user1.address, 1, ftId, gtReward);
+    expect(await ft.balanceOf(user1.address, ftId)).to.equal(expectedFt);
+
+    await house.connect(poo).validateTask(user2.address, 2, ftId, gtReward);
+    expect(await ft.balanceOf(user2.address, ftId)).to.equal(expectedFt);
+
+    // totalGT accumulates across tasks but does not affect individual FT rewards
+    expect(await house.totalGT()).to.equal(gtReward * 2n);
+  });
+});


### PR DESCRIPTION
## Summary
- clarify HouseOfTheLaw FT minting formula to be based on per-task `gtReward`
- document the formula in README
- add unit test demonstrating FT rewards are independent of total GT supply

## Testing
- `npx hardhat test` *(fails: HH502 Couldn't download compiler version list - Proxy response (403) !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_68915f817cd0832aaf8dfcb8e6230b70