### PR TITLE
feat: integrate AI gating into task rewards

### DIFF
--- a/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
+++ b/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
@@ -21,6 +21,10 @@ interface IProofOfObservation {
         returns (address user, uint256 id, string memory proof, bool validated);
 }
 
+interface IAIAssistantGate {
+    function isConsoleOpen(address user) external view returns (bool);
+}
+
 contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     bytes32 public constant VALIDATOR_ROLE = keccak256("VALIDATOR_ROLE");
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
@@ -28,22 +32,25 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
     IFunctionalToken public functionalToken;
     IGTStaking public gtStaking;
     IProofOfObservation public proofOfObservation;
+    IAIAssistantGate public aiGate;
 
     mapping(uint256 => bool) public rewardedTasks;
 
     event TaskRewarded(address indexed user, uint256 taskId, uint256 ftId, uint256 amount);
+    event TaskOffchainValidated(address indexed user, uint256 taskId, bool moderationPassed, bool uniqueSubmission);
 
     constructor() {
         _disableInitializers();
     }
 
-    function initialize(address ftAddr, address stakingAddr, address pooAddr) public initializer {
+    function initialize(address ftAddr, address stakingAddr, address pooAddr, address aiGateAddr) public initializer {
         __AccessControl_init();
         __UUPSUpgradeable_init();
 
         functionalToken = IFunctionalToken(ftAddr);
         gtStaking = IGTStaking(stakingAddr);
         proofOfObservation = IProofOfObservation(pooAddr);
+        aiGate = IAIAssistantGate(aiGateAddr);
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(VALIDATOR_ROLE, msg.sender);
@@ -55,8 +62,13 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
         uint256 tokenId,  // GT used to unlock task
         uint256 taskId,
         uint256 ftId,
-        uint256 ftAmount
+        uint256 ftAmount,
+        bool moderationPassed,
+        bool uniqueSubmission
     ) external onlyRole(VALIDATOR_ROLE) {
+        require(aiGate.isConsoleOpen(user), "AI console not active");
+        require(moderationPassed, "Content moderation failed");
+        require(uniqueSubmission, "Duplicate submission");
         require(gtStaking.isStaked(user, tokenId), "GT not staked");
         require(!rewardedTasks[taskId], "Task already rewarded");
 
@@ -70,6 +82,7 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
 
         rewardedTasks[taskId] = true;
 
+        emit TaskOffchainValidated(user, taskId, moderationPassed, uniqueSubmission);
         emit TaskRewarded(user, taskId, ftId, ftAmount);
     }
 

--- a/contracts/contracts/metaverse/validation/README-info-TaskFlow.md
+++ b/contracts/contracts/metaverse/validation/README-info-TaskFlow.md
@@ -28,6 +28,7 @@ This contract protects the **value and fairness** of the system:
 - ✅ **Prevents double rewards** for the same task
 - ✅ **Ensures real GT commitment** (user had to stake)
 - ✅ **Only rewards verified contributors**
+- ✅ **Enforces AI console gating and off-chain checks**
 - ✅ **Separates proof (PoO) from payout** logic
 
 This contract ensures **only real work gets rewarded** with usable Functional Tokens (FTs) and discourages spam, gaming, or accidental minting.
@@ -41,6 +42,7 @@ This contract ensures **only real work gets rewarded** with usable Functional To
 | `IGTStaking` | Checks if GT was staked, and unstake it afterward |
 | `IFunctionalToken` | Mints the actual reward (FTs) |
 | `IProofOfObservation` | Confirms the task was submitted and validated |
+| `IAIAssistantGate` | Verifies the user's AI console is open |
 
 ---
 
@@ -78,7 +80,8 @@ Now Alice has a tradable or usable token — backed by proof of work.
 initialize(
   address functionalToken,
   address gtStaking,
-  address proofOfObservation
+  address proofOfObservation,
+  address aiGate
 )
 ````
 
@@ -90,7 +93,9 @@ rewardAfterTask(
   uint256 tokenId,  // GT used
   uint256 taskId,
   uint256 ftId,     // FT to be minted
-  uint256 ftAmount
+  uint256 ftAmount,
+  bool moderationPassed,
+  bool uniqueSubmission
 )
 ```
 
@@ -100,7 +105,7 @@ rewardAfterTask(
 
 * 🧠 This contract handles final reward minting for validated, GT-backed tasks
 * 🧷 It verifies the GT was staked, the task was validated, and prevents double-minting
-* 🧩 Works alongside `GTStaking`, `ProofOfObservation`, and `FunctionalToken`
+* 🧩 Works alongside `GTStaking`, `ProofOfObservation`, `AIAssistantGate`, and `FunctionalToken`
 
 This creates a **fair and secure token economy**, ensuring real effort = real reward.
 


### PR DESCRIPTION
## Summary
- require AI console to be open and content/duplication checks to succeed before releasing task rewards
- document new IAIAssistantGate dependency and off-chain validation flags

## Testing
- `npm --prefix contracts run build` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689167cd497c832a94c6c62291670e3f