### PR TITLE
Index faction address in FactionCreated event

### DIFF
--- a/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
+++ b/contracts/contracts/metaverse/core/GenesisBlockFactory.sol
@@ -20,7 +20,7 @@ contract GenesisBlockFactory is AccessControl {
 
     event FactionCreated(
         string indexed name,
-        address faction,
+        address indexed faction,
         address indexed creator,
         string uri,
         uint256 timestamp


### PR DESCRIPTION
## Summary
- index the `faction` address in `FactionCreated` for easier event filtering
- ensure the `emit` call uses the updated event signature

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list, Proxy response (403) when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689179b5dc88832ab2be4192c6db28ab