### PR TITLE
Index task identifiers in PoO task flow events

### DIFF
--- a/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
+++ b/contracts/contracts/metaverse/validation/PoO_TaslkFlow.sol
@@ -36,8 +36,8 @@ contract PoO_TaskFlow is Initializable, UUPSUpgradeable, AccessControlUpgradeabl
 
     mapping(uint256 => bool) public rewardedTasks;
 
-    event TaskRewarded(address indexed user, uint256 taskId, uint256 ftId, uint256 amount);
-    event TaskOffchainValidated(address indexed user, uint256 taskId, bool moderationPassed, bool uniqueSubmission);
+    event TaskRewarded(address indexed user, uint256 indexed taskId, uint256 indexed ftId, uint256 amount);
+    event TaskOffchainValidated(address indexed user, uint256 indexed taskId, bool moderationPassed, bool uniqueSubmission);
 
     constructor() {
         _disableInitializers();


### PR DESCRIPTION
## Summary
- add indexing for `taskId` and `ftId` in `TaskRewarded` event
- add indexing for `taskId` in `TaskOffchainValidated`

## Testing
- `npx hardhat compile --config contracts/hardhat.config.ts` *(fails: Couldn't download compiler version list)*
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68918598c6b8832a988de76c633d4dc1