### PR TITLE
Add TypeScript wrappers and Redux event slices for metaverse contracts

### DIFF
--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,0 +1,1 @@
+export * from './metaverse';

--- a/src/contracts/metaverse.ts
+++ b/src/contracts/metaverse.ts
@@ -1,0 +1,167 @@
+import { Contract, Signer, providers } from 'ethers';
+
+export class GovernanceToken extends Contract {
+  static readonly abi = [
+    'function initialize(string uri_)',
+    'function grantStakingRole(address stakingContract)',
+    'function mintGT(address to,uint256 factionId,uint256 level,uint256 taskId,string proofURI) returns (uint256)',
+    'function stakeTransferFrom(address from,address to,uint256 id,uint256 amount,bytes data)',
+    'function isApprovedForAll(address,address) view returns (bool)',
+    'function getUserGTs(address user) view returns (uint256[])',
+    'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+    'event GTMinted(address indexed to,uint256 tokenId,uint256 indexed factionId,uint256 level,uint256 indexed taskId,string proofURI)',
+    'event StakingRoleGranted(address indexed stakingContract)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, GovernanceToken.abi, signerOrProvider);
+  }
+}
+
+export class FunctionalToken extends Contract {
+  static readonly abi = [
+    'function initialize(string uri_)',
+    'function mint(address to,uint256 id,uint256 amount,bytes data)',
+    'function mintWithPurpose(address to,uint256 id,uint256 amount,bytes data,string purpose)',
+    'function batchRewardMint(address[] recipients,uint256 id,uint256 amount,bytes data)',
+    'function balancesOf(address account,uint256[] ids) view returns (uint256[] balances)',
+    'function safeTransferFrom(address from,address to,uint256 id,uint256 amount,bytes data)',
+    'function safeBatchTransferFrom(address from,address to,uint256[] ids,uint256[] amounts,bytes data)',
+    'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+    'event FunctionalTokenMinted(address indexed to,uint256 indexed id,uint256 amount,string purpose)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, FunctionalToken.abi, signerOrProvider);
+  }
+}
+
+export class MpNSRegistry extends Contract {
+  static readonly abi = [
+    'function initialize()',
+    'function register(string name,address owner,uint256 duration,string uri)',
+    'function updateURI(string name,string newUri)',
+    'function transfer(string name,address newOwner)',
+    'function freezeName(string name)',
+    'function ownerOf(string name) view returns (address)',
+    'function expirationOf(string name) view returns (uint256)',
+    'function nameToUri(string name) view returns (string)',
+    'function isFrozen(string name) view returns (bool)',
+    'event NameRegistered(string indexed name,address indexed owner,uint256 expiration,string uri)',
+    'event URIUpdated(string indexed name,string oldUri,string newUri)',
+    'event NameTransferred(string indexed name,address indexed oldOwner,address indexed newOwner)',
+    'event NameFrozen(string indexed name)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, MpNSRegistry.abi, signerOrProvider);
+  }
+}
+
+export class CrossFactionHub extends Contract {
+  static readonly abi = [
+    'function initialize(address governanceToken_,address poO_,uint256 tokenIdForVoting,address mpnsRegistry_)',
+    'function registerFaction(string factionName)',
+    'function createProposal(string factionName,string title,address target,bytes data) returns (uint256)',
+    'function vote(uint256 proposalId,bool support)',
+    'function executeProposal(uint256 proposalId)',
+    'function getProposal(uint256 proposalId) view returns (tuple(address proposer,address target,bytes data,string title,string faction,uint256 forVotes,uint256 againstVotes,bool executed))',
+    'event FactionRegistered(string indexed faction,address indexed by)',
+    'event ProposalCreated(uint256 indexed id,address indexed proposer,string title,string indexed faction,address indexed target)',
+    'event VoteCast(uint256 indexed id,address indexed voter,bool support,uint256 weight)',
+    'event ProposalExecuted(uint256 indexed id,address indexed executor,address indexed target)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, CrossFactionHub.abi, signerOrProvider);
+  }
+}
+
+export class GTStaking extends Contract {
+  static readonly abi = [
+    'function initialize(address gt_,address ft_,address config_)',
+    'function setTaskMetrics(uint256 taskId,uint256 demand,uint256 supply)',
+    'function stake(uint256 id,uint256 amount)',
+    'function completeTask(uint256 id,uint256 amount,uint256 taskId)',
+    'function calculateReward(uint256 taskId) view returns (uint256)',
+    'function isStaked(address user,uint256 tokenId) view returns (bool)',
+    'function unstake(address user,uint256 tokenId) returns (bool)',
+    'event Staked(address indexed user,uint256 indexed tokenId,uint256 amount)',
+    'event Unstaked(address indexed user,uint256 indexed tokenId,uint256 amount)',
+    'event TaskCompleted(address indexed user,uint256 indexed tokenId,uint256 indexed taskId,uint256 ftReward)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, GTStaking.abi, signerOrProvider);
+  }
+}
+
+export class HouseOfTheLaw extends Contract {
+  static readonly abi = [
+    'function initialize(address functionalToken_,address governanceToken_,address aiGate_,uint256 alphaBps_,uint256 reserveRatioBps_)',
+    'function setProofOfObservation(address poO)',
+    'function setAlpha(uint256 newAlpha)',
+    'function setReserveRatio(uint256 newRatio)',
+    'function validateTask(address user,uint256 taskId,uint256 ftId,uint256 gtReward)',
+    'function createProposal(string description,string ipfsHash,uint256 eligibleGTId,address target,bytes data) returns (uint256)',
+    'function vote(uint256 proposalId,uint256 votes)',
+    'function executeProposal(uint256 proposalId)',
+    'event TaskRewarded(address indexed user,uint256 indexed taskId,uint256 indexed ftId,uint256 ftAmount,uint256 gtReward)',
+    'event ProposalCreated(uint256 indexed proposalId,address indexed proposer,string ipfsHash,uint256 indexed eligibleGTId)',
+    'event ProposalExecuted(uint256 indexed proposalId,address indexed executor,address target,uint256 indexed gtId)',
+    'event Voted(uint256 indexed proposalId,address indexed voter,uint256 votes,uint256 cost,uint256 indexed gtId)',
+    'event AlphaUpdated(uint256 oldAlpha,uint256 newAlpha,address indexed caller)',
+    'event ReserveRatioUpdated(uint256 oldRatio,uint256 newRatio,address indexed caller)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, HouseOfTheLaw.abi, signerOrProvider);
+  }
+}
+
+export class ProofOfObservation extends Contract {
+  static readonly abi = [
+    'function initialize(address houseOfTheLawAddress)',
+    'function submitTask(uint256 taskId,string proof)',
+    'function validateTask(address user,uint256 taskId,uint256 ftId,uint256 gtReward)',
+    'function isValidated(address user) view returns (bool)',
+    'event TaskSubmitted(address indexed user,uint256 indexed taskId,string proof)',
+    'event TaskValidated(address indexed validator,address indexed user,uint256 indexed taskId,uint256 gtReward)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, ProofOfObservation.abi, signerOrProvider);
+  }
+}
+
+export class PoO_TaskFlow extends Contract {
+  static readonly abi = [
+    'function initialize(address ftAddr,address stakingAddr,address pooAddr,address aiGateAddr)',
+    'function rewardAfterTask(address user,uint256 tokenId,uint256 taskId,uint256 ftId,uint256 ftAmount,bool moderationPassed,bool uniqueSubmission)',
+    'event TaskRewarded(address indexed user,uint256 indexed taskId,uint256 indexed ftId,uint256 amount)',
+    'event TaskOffchainValidated(address indexed user,uint256 indexed taskId,bool moderationPassed,bool uniqueSubmission)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, PoO_TaskFlow.abi, signerOrProvider);
+  }
+}
+
+export class GenesisBlockFaction extends Contract {
+  static readonly abi = [
+    'function initialize(address mpnsAddress,address creatorAddress,string factionName)',
+    'function mpns() view returns (address)',
+    'function creator() view returns (address)',
+    'function name() view returns (string)',
+    'function uri() view returns (string)',
+    'function timestamp() view returns (uint256)',
+    'event FactionInitialized(string indexed name,address indexed creator,string uri,uint256 timestamp)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, GenesisBlockFaction.abi, signerOrProvider);
+  }
+}
+
+export class GenesisBlockFactory extends Contract {
+  static readonly abi = [
+    'function createFaction(string name) returns (address)',
+    'function getAllFactions() view returns (string[])',
+    'event FactionCreated(string indexed name,address indexed faction,address indexed creator,string uri,uint256 timestamp)'
+  ] as const;
+  constructor(address: string, signerOrProvider: Signer | providers.Provider) {
+    super(address, GenesisBlockFactory.abi, signerOrProvider);
+  }
+}
+

--- a/src/store/eventSlices.js
+++ b/src/store/eventSlices.js
@@ -1,0 +1,78 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const createEventSlice = (name) =>
+  createSlice({
+    name,
+    initialState: [],
+    reducers: {
+      addEvent(state, action) {
+        state.push(action.payload);
+      },
+      clearEvents() {
+        return [];
+      },
+    },
+  });
+
+const governanceTokenEvents = createEventSlice('governanceTokenEvents');
+const functionalTokenEvents = createEventSlice('functionalTokenEvents');
+const mpnsRegistryEvents = createEventSlice('mpnsRegistryEvents');
+const crossFactionHubEvents = createEventSlice('crossFactionHubEvents');
+const gtStakingEvents = createEventSlice('gtStakingEvents');
+const houseOfTheLawEvents = createEventSlice('houseOfTheLawEvents');
+const proofOfObservationEvents = createEventSlice('proofOfObservationEvents');
+const pooTaskFlowEvents = createEventSlice('pooTaskFlowEvents');
+const genesisBlockFactionEvents = createEventSlice('genesisBlockFactionEvents');
+const genesisBlockFactoryEvents = createEventSlice('genesisBlockFactoryEvents');
+
+export const {
+  addEvent: addGovernanceTokenEvent,
+  clearEvents: clearGovernanceTokenEvents,
+} = governanceTokenEvents.actions;
+export const {
+  addEvent: addFunctionalTokenEvent,
+  clearEvents: clearFunctionalTokenEvents,
+} = functionalTokenEvents.actions;
+export const {
+  addEvent: addMpnsRegistryEvent,
+  clearEvents: clearMpnsRegistryEvents,
+} = mpnsRegistryEvents.actions;
+export const {
+  addEvent: addCrossFactionHubEvent,
+  clearEvents: clearCrossFactionHubEvents,
+} = crossFactionHubEvents.actions;
+export const {
+  addEvent: addGtStakingEvent,
+  clearEvents: clearGtStakingEvents,
+} = gtStakingEvents.actions;
+export const {
+  addEvent: addHouseOfTheLawEvent,
+  clearEvents: clearHouseOfTheLawEvents,
+} = houseOfTheLawEvents.actions;
+export const {
+  addEvent: addProofOfObservationEvent,
+  clearEvents: clearProofOfObservationEvents,
+} = proofOfObservationEvents.actions;
+export const {
+  addEvent: addPooTaskFlowEvent,
+  clearEvents: clearPooTaskFlowEvents,
+} = pooTaskFlowEvents.actions;
+export const {
+  addEvent: addGenesisBlockFactionEvent,
+  clearEvents: clearGenesisBlockFactionEvents,
+} = genesisBlockFactionEvents.actions;
+export const {
+  addEvent: addGenesisBlockFactoryEvent,
+  clearEvents: clearGenesisBlockFactoryEvents,
+} = genesisBlockFactoryEvents.actions;
+
+export const governanceTokenEventsReducer = governanceTokenEvents.reducer;
+export const functionalTokenEventsReducer = functionalTokenEvents.reducer;
+export const mpnsRegistryEventsReducer = mpnsRegistryEvents.reducer;
+export const crossFactionHubEventsReducer = crossFactionHubEvents.reducer;
+export const gtStakingEventsReducer = gtStakingEvents.reducer;
+export const houseOfTheLawEventsReducer = houseOfTheLawEvents.reducer;
+export const proofOfObservationEventsReducer = proofOfObservationEvents.reducer;
+export const pooTaskFlowEventsReducer = pooTaskFlowEvents.reducer;
+export const genesisBlockFactionEventsReducer = genesisBlockFactionEvents.reducer;
+export const genesisBlockFactoryEventsReducer = genesisBlockFactoryEvents.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,11 +2,33 @@ import { configureStore } from '@reduxjs/toolkit';
 import gtReducer from './gtSlice';
 import taskReducer from './taskSlice';
 import aiReducer from './aiSlice';
+import {
+  governanceTokenEventsReducer,
+  functionalTokenEventsReducer,
+  mpnsRegistryEventsReducer,
+  crossFactionHubEventsReducer,
+  gtStakingEventsReducer,
+  houseOfTheLawEventsReducer,
+  proofOfObservationEventsReducer,
+  pooTaskFlowEventsReducer,
+  genesisBlockFactionEventsReducer,
+  genesisBlockFactoryEventsReducer,
+} from './eventSlices';
 
 export const store = configureStore({
   reducer: {
     gt: gtReducer,
     task: taskReducer,
     ai: aiReducer,
+    governanceTokenEvents: governanceTokenEventsReducer,
+    functionalTokenEvents: functionalTokenEventsReducer,
+    mpnsRegistryEvents: mpnsRegistryEventsReducer,
+    crossFactionHubEvents: crossFactionHubEventsReducer,
+    gtStakingEvents: gtStakingEventsReducer,
+    houseOfTheLawEvents: houseOfTheLawEventsReducer,
+    proofOfObservationEvents: proofOfObservationEventsReducer,
+    pooTaskFlowEvents: pooTaskFlowEventsReducer,
+    genesisBlockFactionEvents: genesisBlockFactionEventsReducer,
+    genesisBlockFactoryEvents: genesisBlockFactoryEventsReducer,
   },
 });


### PR DESCRIPTION
## Summary
- add Ethers.js TypeScript classes wrapping GovernanceToken, FunctionalToken, MpNSRegistry, CrossFactionHub, GTStaking, HouseOfTheLaw, ProofOfObservation, PoO_TaskFlow, GenesisBlockFaction, and GenesisBlockFactory
- expose the wrappers through a shared `src/contracts` module
- track on-chain activity with Redux slices for each contract's events and register them in the store

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68918ce4d830832aad23882476228236