### PR TITLE
Add role management to contract wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ cd contracts
 npm install
 npx hardhat compile
 ```
+
+### Roles and Permissions
+Many contract interactions are restricted by Access Control roles. Common UI actions require the following roles:
+
+- **MINTER_ROLE** – needed to mint tokens such as `FunctionalToken.mint` or `GovernanceToken.mintGT`.
+- **REGISTRAR_ROLE** – required to register new names in the `MpNSRegistry`.
+- **VALIDATOR_ROLE** – required for task validation flows like `ProofOfObservation.validateTask` or `PoO_TaskFlow.rewardAfterTask`.
+- **DEFAULT_ADMIN_ROLE** – allows role management through `grantRole` and `revokeRole`.
+
+Ensure the connected wallet has the appropriate role before performing these actions in the UI.
 Scripts
 npm start: Runs the app in development mode.
 npm test: Launches the test runner.

--- a/src/contracts/metaverse.ts
+++ b/src/contracts/metaverse.ts
@@ -9,6 +9,9 @@ export class GovernanceToken extends Contract {
     'function isApprovedForAll(address,address) view returns (bool)',
     'function getUserGTs(address user) view returns (uint256[])',
     'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event GTMinted(address indexed to,uint256 tokenId,uint256 indexed factionId,uint256 level,uint256 indexed taskId,string proofURI)',
     'event StakingRoleGranted(address indexed stakingContract)'
   ] as const;
@@ -27,6 +30,9 @@ export class FunctionalToken extends Contract {
     'function safeTransferFrom(address from,address to,uint256 id,uint256 amount,bytes data)',
     'function safeBatchTransferFrom(address from,address to,uint256[] ids,uint256[] amounts,bytes data)',
     'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event FunctionalTokenMinted(address indexed to,uint256 indexed id,uint256 amount,string purpose)'
   ] as const;
   constructor(address: string, signerOrProvider: Signer | providers.Provider) {
@@ -45,6 +51,9 @@ export class MpNSRegistry extends Contract {
     'function expirationOf(string name) view returns (uint256)',
     'function nameToUri(string name) view returns (string)',
     'function isFrozen(string name) view returns (bool)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event NameRegistered(string indexed name,address indexed owner,uint256 expiration,string uri)',
     'event URIUpdated(string indexed name,string oldUri,string newUri)',
     'event NameTransferred(string indexed name,address indexed oldOwner,address indexed newOwner)',
@@ -63,6 +72,9 @@ export class CrossFactionHub extends Contract {
     'function vote(uint256 proposalId,bool support)',
     'function executeProposal(uint256 proposalId)',
     'function getProposal(uint256 proposalId) view returns (tuple(address proposer,address target,bytes data,string title,string faction,uint256 forVotes,uint256 againstVotes,bool executed))',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event FactionRegistered(string indexed faction,address indexed by)',
     'event ProposalCreated(uint256 indexed id,address indexed proposer,string title,string indexed faction,address indexed target)',
     'event VoteCast(uint256 indexed id,address indexed voter,bool support,uint256 weight)',
@@ -82,6 +94,9 @@ export class GTStaking extends Contract {
     'function calculateReward(uint256 taskId) view returns (uint256)',
     'function isStaked(address user,uint256 tokenId) view returns (bool)',
     'function unstake(address user,uint256 tokenId) returns (bool)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event Staked(address indexed user,uint256 indexed tokenId,uint256 amount)',
     'event Unstaked(address indexed user,uint256 indexed tokenId,uint256 amount)',
     'event TaskCompleted(address indexed user,uint256 indexed tokenId,uint256 indexed taskId,uint256 ftReward)'
@@ -101,6 +116,9 @@ export class HouseOfTheLaw extends Contract {
     'function createProposal(string description,string ipfsHash,uint256 eligibleGTId,address target,bytes data) returns (uint256)',
     'function vote(uint256 proposalId,uint256 votes)',
     'function executeProposal(uint256 proposalId)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event TaskRewarded(address indexed user,uint256 indexed taskId,uint256 indexed ftId,uint256 ftAmount,uint256 gtReward)',
     'event ProposalCreated(uint256 indexed proposalId,address indexed proposer,string ipfsHash,uint256 indexed eligibleGTId)',
     'event ProposalExecuted(uint256 indexed proposalId,address indexed executor,address target,uint256 indexed gtId)',
@@ -119,6 +137,9 @@ export class ProofOfObservation extends Contract {
     'function submitTask(uint256 taskId,string proof)',
     'function validateTask(address user,uint256 taskId,uint256 ftId,uint256 gtReward)',
     'function isValidated(address user) view returns (bool)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event TaskSubmitted(address indexed user,uint256 indexed taskId,string proof)',
     'event TaskValidated(address indexed validator,address indexed user,uint256 indexed taskId,uint256 gtReward)'
   ] as const;
@@ -131,6 +152,9 @@ export class PoO_TaskFlow extends Contract {
   static readonly abi = [
     'function initialize(address ftAddr,address stakingAddr,address pooAddr,address aiGateAddr)',
     'function rewardAfterTask(address user,uint256 tokenId,uint256 taskId,uint256 ftId,uint256 ftAmount,bool moderationPassed,bool uniqueSubmission)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event TaskRewarded(address indexed user,uint256 indexed taskId,uint256 indexed ftId,uint256 amount)',
     'event TaskOffchainValidated(address indexed user,uint256 indexed taskId,bool moderationPassed,bool uniqueSubmission)'
   ] as const;
@@ -147,6 +171,9 @@ export class GenesisBlockFaction extends Contract {
     'function name() view returns (string)',
     'function uri() view returns (string)',
     'function timestamp() view returns (uint256)',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event FactionInitialized(string indexed name,address indexed creator,string uri,uint256 timestamp)'
   ] as const;
   constructor(address: string, signerOrProvider: Signer | providers.Provider) {
@@ -158,6 +185,9 @@ export class GenesisBlockFactory extends Contract {
   static readonly abi = [
     'function createFaction(string name) returns (address)',
     'function getAllFactions() view returns (string[])',
+    'function grantRole(bytes32 role,address account)',
+    'function revokeRole(bytes32 role,address account)',
+    'function hasRole(bytes32 role,address account) view returns (bool)',
     'event FactionCreated(string indexed name,address indexed faction,address indexed creator,string uri,uint256 timestamp)'
   ] as const;
   constructor(address: string, signerOrProvider: Signer | providers.Provider) {


### PR DESCRIPTION
## Summary
- add grantRole, revokeRole, and hasRole entries to all metaverse contract wrapper ABIs
- document access-control roles required for common UI actions

## Testing
- `npx hardhat compile` (fails: Couldn't download compiler version list; Proxy response (403) !== 200)
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891ba739afc832aaa6c2b2855f13655