### PR TITLE
feat: add typed contract events and interfaces

### DIFF
--- a/src/contracts/metaverse.ts
+++ b/src/contracts/metaverse.ts
@@ -1,5 +1,10 @@
 import { Contract, Signer, providers } from 'ethers';
-import type { Proposal, TaskMetrics } from './types';
+import type {
+  Proposal,
+  TaskMetrics,
+  ProposalCreatedEvent,
+  VoteCastEvent,
+} from './types';
 
 export class GovernanceToken extends Contract {
   static readonly abi = [
@@ -84,10 +89,53 @@ export class CrossFactionHub extends Contract {
   constructor(address: string, signerOrProvider: Signer | providers.Provider) {
     super(address, CrossFactionHub.abi, signerOrProvider);
   }
+
+  async queryProposalCreatedEvents(
+    fromBlock?: number | string,
+    toBlock?: number | string,
+  ): Promise<ProposalCreatedEvent[]> {
+    const events = await this.queryFilter(
+      this.filters.ProposalCreated(),
+      fromBlock,
+      toBlock,
+    );
+    return events.map((e) => ({
+      id: e.args?.id as bigint,
+      proposer: e.args?.proposer as string,
+      title: e.args?.title as string,
+      faction: e.args?.faction as string,
+      target: e.args?.target as string,
+    }));
+  }
+
+  async queryVoteCastEvents(
+    fromBlock?: number | string,
+    toBlock?: number | string,
+  ): Promise<VoteCastEvent[]> {
+    const events = await this.queryFilter(
+      this.filters.VoteCast(),
+      fromBlock,
+      toBlock,
+    );
+    return events.map((e) => ({
+      id: e.args?.id as bigint,
+      voter: e.args?.voter as string,
+      support: e.args?.support as boolean,
+      weight: e.args?.weight as bigint,
+    }));
+  }
 }
 
 export interface CrossFactionHub {
   getProposal(proposalId: bigint): Promise<Proposal>;
+  queryProposalCreatedEvents(
+    fromBlock?: number | string,
+    toBlock?: number | string,
+  ): Promise<ProposalCreatedEvent[]>;
+  queryVoteCastEvents(
+    fromBlock?: number | string,
+    toBlock?: number | string,
+  ): Promise<VoteCastEvent[]>;
 }
 
 export class GTStaking extends Contract {

--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -17,6 +17,13 @@ export interface ProposalCreatedEvent {
   target: string;
 }
 
+export interface VoteCastEvent {
+  id: bigint;
+  voter: string;
+  support: boolean;
+  weight: bigint;
+}
+
 export interface TaskMetrics {
   demand: bigint;
   supply: bigint;

--- a/src/sections/TaskManager/TaskManager.tsx
+++ b/src/sections/TaskManager/TaskManager.tsx
@@ -35,7 +35,7 @@ const TaskManager: React.FC = () => {
       try {
         const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
         const staking = new GTStaking(STAKING_ADDRESS, provider);
-        const metrics = await staking.taskMetrics(1n) as TaskMetrics;
+        const metrics: TaskMetrics = await staking.taskMetrics(1n);
         dispatch(updateMetrics({ taskId: 1, metrics }));
       } catch (error) {
         console.error('Error fetching task metrics:', error);


### PR DESCRIPTION
## Summary
- add interfaces for proposal, vote events, and task metrics
- expose typed event queries in CrossFactionHub wrapper
- rely on typed TaskMetrics in TaskManager without manual cast

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6891c65f60d4832ab1ac198ea06d1909