### PR TITLE
feat: add provider service and document blockchain env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ npm install
 npx hardhat compile
 ```
 
+### Deployment
+
+Configure the following environment variables when deploying to define the blockchain connection:
+
+- `RPC_URL` – HTTP endpoint of the Ethereum network used if no injected provider is present.
+- `CHAIN_ID` – Network chain identifier corresponding to the RPC endpoint.
+
 ### Roles and Permissions
 Many contract interactions are restricted by Access Control roles. Common UI actions require the following roles:
 

--- a/src/contracts/loadContract.ts
+++ b/src/contracts/loadContract.ts
@@ -1,6 +1,7 @@
-import { Contract, Signer, providers, ethers } from 'ethers';
+import { Contract, Signer, ethers } from 'ethers';
 import addresses from './metadata/addresses.json';
 import GovernanceToken from './metadata/GovernanceToken.json';
+import { getProvider } from '../services/provider';
 
 type AddressBook = Record<string, Record<string, string>>;
 const abis: Record<string, any> = {
@@ -9,11 +10,10 @@ const abis: Record<string, any> = {
 
 export async function loadContract(
   name: keyof typeof abis,
-  signerOrProvider: Signer | providers.Provider
+  signer?: Signer
 ): Promise<Contract> {
-  const network = await (signerOrProvider instanceof Signer
-    ? signerOrProvider.provider!.getNetwork()
-    : signerOrProvider.getNetwork());
+  const provider = signer?.provider ?? getProvider();
+  const network = await provider.getNetwork();
 
   const address = (addresses as AddressBook)[network.name]?.[name as string];
   if (!address) {
@@ -21,7 +21,7 @@ export async function loadContract(
   }
 
   const abi = abis[name as string];
-  return new ethers.Contract(address, abi, signerOrProvider);
+  return new ethers.Contract(address, abi, signer ?? provider);
 }
 
 export default loadContract;

--- a/src/services/blockchainService.js
+++ b/src/services/blockchainService.js
@@ -1,9 +1,10 @@
-import { ethers } from 'ethers';
 import loadContract from '../contracts/loadContract';
+import { getSigner } from './provider';
 
-const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-
-const getContract = (account) => loadContract('GovernanceToken', provider.getSigner(account));
+const getContract = async (account) => {
+  const signer = await getSigner(account);
+  return loadContract('GovernanceToken', signer);
+};
 
 // Function to upload metadata to IPFS
 export const uploadMetadataToIPFS = async (metadata) => {

--- a/src/services/provider.js
+++ b/src/services/provider.js
@@ -1,0 +1,30 @@
+import { ethers } from 'ethers';
+
+let provider;
+
+export const getProvider = () => {
+  if (provider) return provider;
+
+  if (typeof window !== 'undefined' && window.ethereum) {
+    provider = new ethers.providers.Web3Provider(window.ethereum);
+  } else {
+    const rpcUrl = process.env.RPC_URL || 'http://localhost:8545';
+    const chainId = process.env.CHAIN_ID ? parseInt(process.env.CHAIN_ID, 10) : undefined;
+    provider = new ethers.providers.JsonRpcProvider(rpcUrl, chainId);
+  }
+
+  return provider;
+};
+
+export const getSigner = async (account) => {
+  const prov = getProvider();
+  if (typeof window !== 'undefined' && window.ethereum) {
+    await prov.send('eth_requestAccounts', []);
+  }
+  return prov.getSigner(account);
+};
+
+export default {
+  getProvider,
+  getSigner,
+};


### PR DESCRIPTION
## Summary
- create provider service to derive ethers provider and signer from window.ethereum or RPC fallback
- wire contract loader and blockchain service to use shared provider
- document RPC_URL and CHAIN_ID deployment variables

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891cc4afab4832a80dc9fa44cbe353d