### PR TITLE
Integrate contract caching and permissioned minting

### DIFF
--- a/src/sections/TaskManager/TaskManager.tsx
+++ b/src/sections/TaskManager/TaskManager.tsx
@@ -1,13 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { ethers } from 'ethers';
 import { useDispatch } from 'react-redux';
 import aiService from '../../services/aiService';
-import { GTStaking } from '../../contracts';
-import type { TaskMetrics } from '../../contracts/types';
-import { updateMetrics } from '../../store/taskSlice';
+import { fetchTaskMetrics } from '../../store/taskSlice';
 import './TaskManager.css';
-
-const STAKING_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const TaskManager: React.FC = () => {
   const [tasks, setTasks] = useState<string[]>([]);
@@ -31,18 +26,7 @@ const TaskManager: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const fetchMetrics = async () => {
-      try {
-        const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-        const staking = new GTStaking(STAKING_ADDRESS, provider);
-        const metrics: TaskMetrics = await staking.taskMetrics(1n);
-        dispatch(updateMetrics({ taskId: 1, metrics }));
-      } catch (error) {
-        console.error('Error fetching task metrics:', error);
-      }
-    };
-
-    fetchMetrics();
+    dispatch(fetchTaskMetrics(1));
   }, [dispatch]);
 
   const handleTaskCompletion = (task: string) => {

--- a/src/services/contractService.ts
+++ b/src/services/contractService.ts
@@ -1,0 +1,30 @@
+import { GTStaking } from '../contracts';
+import { getProvider } from './provider';
+import type { TaskMetrics } from '../contracts/types';
+
+let stakingInstance: GTStaking | undefined;
+const metricsCache = new Map<number, TaskMetrics>();
+
+const STAKING_ADDRESS = process.env.REACT_APP_GT_STAKING_ADDRESS || process.env.GT_STAKING_ADDRESS || '0x0000000000000000000000000000000000000000';
+
+export const getGTStaking = async (): Promise<GTStaking> => {
+  if (!stakingInstance) {
+    const provider = getProvider();
+    stakingInstance = new GTStaking(STAKING_ADDRESS, provider);
+  }
+  return stakingInstance;
+};
+
+export const getTaskMetrics = async (taskId: number): Promise<TaskMetrics> => {
+  const cached = metricsCache.get(taskId);
+  if (cached) return cached;
+  const staking = await getGTStaking();
+  const metrics = await staking.taskMetrics(BigInt(taskId));
+  metricsCache.set(taskId, metrics);
+  return metrics;
+};
+
+export default {
+  getGTStaking,
+  getTaskMetrics,
+};

--- a/src/services/hashUtils.js
+++ b/src/services/hashUtils.js
@@ -1,5 +1,6 @@
 import CryptoJS from 'crypto-js';
 import blockchainService from './blockchainService';
+import { getProvider } from './provider';
 
 // Function to create SHA-256 hash
 export const createHash = (data) => {
@@ -19,8 +20,10 @@ export const createBlock = async (previousBlockHash, metadata) => {
     const metadataHash = await blockchainService.uploadMetadataToIPFS(metadata);
 
     // Store new block hash and metadata hash on the blockchain
-    const account = await web3.eth.getAccounts()[0]; // Get the first account
-    await blockchainService.createToken(account, newBlockHash, 1, metadataHash);
+    const provider = getProvider();
+    const accounts = await provider.listAccounts();
+    const account = accounts[0];
+    await blockchainService.mintGovernanceToken(account, 0, 0, 0, metadataHash);
 
     return newBlockHash;
   } catch (error) {

--- a/src/store/taskSlice.ts
+++ b/src/store/taskSlice.ts
@@ -1,5 +1,6 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import type { TaskMetrics } from '../contracts/types';
+import { getTaskMetrics } from '../services/contractService';
 
 interface TaskState {
   tasks: any[];
@@ -13,6 +14,14 @@ const initialState: TaskState = {
   metrics: {},
 };
 
+export const fetchTaskMetrics = createAsyncThunk(
+  'task/fetchMetrics',
+  async (taskId: number) => {
+    const metrics = await getTaskMetrics(taskId);
+    return { taskId, metrics };
+  }
+);
+
 const taskSlice = createSlice({
   name: 'task',
   initialState,
@@ -23,13 +32,14 @@ const taskSlice = createSlice({
     setCurrentTask(state, action: PayloadAction<any>) {
       state.currentTask = action.payload;
     },
-    updateMetrics(state, action: PayloadAction<{ taskId: number; metrics: TaskMetrics }>) {
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchTaskMetrics.fulfilled, (state, action) => {
       const { taskId, metrics } = action.payload;
       state.metrics[taskId] = metrics;
-    },
+    });
   },
 });
 
-export const { setTasks, setCurrentTask, updateMetrics } = taskSlice.actions;
+export const { setTasks, setCurrentTask } = taskSlice.actions;
 export default taskSlice.reducer;
-


### PR DESCRIPTION
## Summary
- add GovernanceToken mint helper with MINTER_ROLE check
- cache GTStaking contract and metrics in new contractService
- refactor task slice and TaskManager to fetch metrics via async thunk

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891d2fab33c832a8d89f45870e17156