### PR TITLE
feat: add service interfaces for gt, house of the law, and tasks

### DIFF
--- a/src/services/gtService.ts
+++ b/src/services/gtService.ts
@@ -1,0 +1,73 @@
+import { GovernanceToken, GTStaking } from '../contracts';
+import { getProvider, getSigner } from './provider';
+
+export interface StakeParams {
+  id: number;
+  amount: bigint;
+}
+
+export interface GTService {
+  getGovernanceToken(): Promise<GovernanceToken>;
+  getGTStaking(): Promise<GTStaking>;
+  fetchUserGTs(user: string): Promise<bigint[]>;
+  stake(params: StakeParams): Promise<any>;
+  unstake(tokenId: number): Promise<any>;
+}
+
+let governanceToken: GovernanceToken | undefined;
+let stakingInstance: GTStaking | undefined;
+
+const GOVERNANCE_TOKEN_ADDRESS =
+  process.env.REACT_APP_GOVERNANCE_TOKEN_ADDRESS ||
+  process.env.GOVERNANCE_TOKEN_ADDRESS ||
+  '0x0000000000000000000000000000000000000000';
+
+const GT_STAKING_ADDRESS =
+  process.env.REACT_APP_GT_STAKING_ADDRESS ||
+  process.env.GT_STAKING_ADDRESS ||
+  '0x0000000000000000000000000000000000000000';
+
+export const getGovernanceToken = async (): Promise<GovernanceToken> => {
+  if (!governanceToken) {
+    const provider = getProvider();
+    governanceToken = new GovernanceToken(GOVERNANCE_TOKEN_ADDRESS, provider);
+  }
+  return governanceToken;
+};
+
+export const getGTStaking = async (): Promise<GTStaking> => {
+  if (!stakingInstance) {
+    const provider = getProvider();
+    stakingInstance = new GTStaking(GT_STAKING_ADDRESS, provider);
+  }
+  return stakingInstance;
+};
+
+export const fetchUserGTs = async (user: string): Promise<bigint[]> => {
+  const gt = await getGovernanceToken();
+  return gt.getUserGTs(user);
+};
+
+export const stake = async ({ id, amount }: StakeParams) => {
+  const staking = await getGTStaking();
+  const signer = await getSigner();
+  return staking.connect(signer).stake(BigInt(id), amount);
+};
+
+export const unstake = async (tokenId: number) => {
+  const staking = await getGTStaking();
+  const signer = await getSigner();
+  return staking
+    .connect(signer)
+    .unstake(await signer.getAddress(), BigInt(tokenId));
+};
+
+const service: GTService = {
+  getGovernanceToken,
+  getGTStaking,
+  fetchUserGTs,
+  stake,
+  unstake,
+};
+
+export default service;

--- a/src/services/houseOfTheLawService.ts
+++ b/src/services/houseOfTheLawService.ts
@@ -1,0 +1,77 @@
+import { HouseOfTheLaw } from '../contracts';
+import { getProvider, getSigner } from './provider';
+
+export interface ProposalParams {
+  description: string;
+  ipfsHash: string;
+  eligibleGTId: number;
+  target: string;
+  data: string;
+}
+
+export interface VoteParams {
+  proposalId: number;
+  votes: number;
+}
+
+export interface ValidationParams {
+  user: string;
+  taskId: number;
+  ftId: number;
+  gtReward: number;
+}
+
+export interface HouseOfTheLawService {
+  getHouse(): Promise<HouseOfTheLaw>;
+  createProposal(params: ProposalParams): Promise<any>;
+  vote(params: VoteParams): Promise<any>;
+  validateTask(params: ValidationParams): Promise<any>;
+}
+
+let houseInstance: HouseOfTheLaw | undefined;
+
+const HOTL_ADDRESS =
+  process.env.REACT_APP_HOUSE_OF_THE_LAW_ADDRESS ||
+  process.env.HOUSE_OF_THE_LAW_ADDRESS ||
+  '0x0000000000000000000000000000000000000000';
+
+export const getHouse = async (): Promise<HouseOfTheLaw> => {
+  if (!houseInstance) {
+    const provider = getProvider();
+    houseInstance = new HouseOfTheLaw(HOTL_ADDRESS, provider);
+  }
+  return houseInstance;
+};
+
+export const createProposal = async (params: ProposalParams) => {
+  const { description, ipfsHash, eligibleGTId, target, data } = params;
+  const hotl = await getHouse();
+  const signer = await getSigner();
+  return hotl
+    .connect(signer)
+    .createProposal(description, ipfsHash, BigInt(eligibleGTId), target, data);
+};
+
+export const vote = async ({ proposalId, votes }: VoteParams) => {
+  const hotl = await getHouse();
+  const signer = await getSigner();
+  return hotl.connect(signer).vote(BigInt(proposalId), BigInt(votes));
+};
+
+export const validateTask = async (params: ValidationParams) => {
+  const { user, taskId, ftId, gtReward } = params;
+  const hotl = await getHouse();
+  const signer = await getSigner();
+  return hotl
+    .connect(signer)
+    .validateTask(user, BigInt(taskId), BigInt(ftId), BigInt(gtReward));
+};
+
+const service: HouseOfTheLawService = {
+  getHouse,
+  createProposal,
+  vote,
+  validateTask,
+};
+
+export default service;

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -2,15 +2,23 @@ import { GTStaking } from '../contracts';
 import { getProvider } from './provider';
 import type { TaskMetrics } from '../contracts/types';
 
+export interface TaskService {
+  getGTStaking(): Promise<GTStaking>;
+  getTaskMetrics(taskId: number): Promise<TaskMetrics>;
+}
+
 let stakingInstance: GTStaking | undefined;
 const metricsCache = new Map<number, TaskMetrics>();
 
-const STAKING_ADDRESS = process.env.REACT_APP_GT_STAKING_ADDRESS || process.env.GT_STAKING_ADDRESS || '0x0000000000000000000000000000000000000000';
+const GT_STAKING_ADDRESS =
+  process.env.REACT_APP_GT_STAKING_ADDRESS ||
+  process.env.GT_STAKING_ADDRESS ||
+  '0x0000000000000000000000000000000000000000';
 
 export const getGTStaking = async (): Promise<GTStaking> => {
   if (!stakingInstance) {
     const provider = getProvider();
-    stakingInstance = new GTStaking(STAKING_ADDRESS, provider);
+    stakingInstance = new GTStaking(GT_STAKING_ADDRESS, provider);
   }
   return stakingInstance;
 };
@@ -24,7 +32,9 @@ export const getTaskMetrics = async (taskId: number): Promise<TaskMetrics> => {
   return metrics;
 };
 
-export default {
+const service: TaskService = {
   getGTStaking,
   getTaskMetrics,
 };
+
+export default service;

--- a/src/store/README.md
+++ b/src/store/README.md
@@ -1,0 +1,75 @@
+# Redux Store Overview
+
+This directory houses Redux slices that hold application state for the AI‑Powered Metaverse Platform. Each section below explains what a slice tracks, when it changes, and how it ties into smart contracts and the interface.
+
+## AI Recommendations (`ai`)
+- **What it does:** stores AI generated suggestions for the user interface.
+- **Key action:** `setRecommendations`.
+  - Trigger: API call to the AI service completes.
+  - Effect: updates the list of tips shown in the AI console; no blockchain interaction.
+- **Example flow:** user opens the AI helper → front end requests recommendations → `setRecommendations` saves them → UI lists the new tips.
+
+## Governance Token (`gt`)
+- **What it does:** keeps the user’s governance token profile, wallet balance, and staked amounts.
+- **Key actions:**
+  - `setProfile` – triggered after reading on-chain profile when the wallet connects. Updates faction and level displayed in the UI.
+  - `setBalance` – called after a balance query or token transfer. Refreshes the token amount shown.
+  - `stakeGT` – fired when a user clicks a “Stake” button. Sends a transaction to the `GTStaking` contract and adjusts local balance and staked record.
+  - `unstakeGT` – triggered by an “Unstake” action. Calls `GTStaking` to release tokens and updates the store.
+- **Connections:** interacts with the `GovernanceToken` and `GTStaking` contracts and drives features that depend on token ownership or staking.
+- **Example flow:** user connects wallet → app fetches faction/level → `setProfile` updates store → dashboard shows faction content; later the user stakes tokens → blockchain transaction succeeds → `stakeGT` updates balances → staking widgets reflect new totals.
+
+## Tasks (`task`)
+- **What it does:** holds available tasks, the currently selected task, and metrics pulled from the blockchain.
+- **Key actions:**
+  - `setTasks` – invoked after tasks are fetched from an API or contract. Populates the task list.
+  - `setCurrentTask` – user selects a task; UI highlights it.
+  - `fetchTaskMetrics` – async thunk that calls `getTaskMetrics` (reads `GTStaking.taskMetrics`). When it resolves, metrics are stored for display.
+- **Example flow:** user opens the tasks page → `setTasks` loads tasks → user clicks one → `setCurrentTask` sets it → `fetchTaskMetrics` retrieves metrics → UI shows completion stats.
+
+## Contract Event Logs
+Each of the following slices records events emitted by a specific smart contract. They share two actions:
+- `add<Event>` – dispatched by a Web3 event listener when the contract emits an event.
+- `clear<Events>` – triggered by a user action to wipe the log.
+
+### Governance Token Events (`governanceTokenEvents`)
+- Tracks minting and transfer events from the `GovernanceToken` contract.
+- Example flow: user mints GT → event fires → `addGovernanceTokenEvent` saves it → notifications panel lists the mint.
+
+### Functional Token Events (`functionalTokenEvents`)
+- Logs events from the `FunctionalToken` contract.
+- Example flow: functional token minted → listener dispatches `addFunctionalTokenEvent` → UI shows the activity.
+
+### MpNS Registry Events (`mpnsRegistryEvents`)
+- Watches registrations in the `MpNSRegistry` name service.
+- Example flow: a name is registered → `addMpnsRegistryEvent` records it → name registry page updates.
+
+### Cross Faction Hub Events (`crossFactionHubEvents`)
+- Captures governance activity from `CrossFactionHub`.
+- Example flow: hub proposal created → `addCrossFactionHubEvent` logs it → governance feed shows the new proposal.
+
+### GT Staking Events (`gtStakingEvents`)
+- Reflects staking/unstaking events from `GTStaking`.
+- Example flow: user stakes tokens → `addGtStakingEvent` runs after the contract event → staking history updates.
+
+### House Of The Law Events (`houseOfTheLawEvents`)
+- Monitors actions within `HouseOfTheLaw` (proposal validation, etc.).
+- Example flow: law proposal validated → `addHouseOfTheLawEvent` stores it → law console shows the validation.
+
+### Proof Of Observation Events (`proofOfObservationEvents`)
+- Logs submissions and validations for `ProofOfObservation`.
+- Example flow: task observation submitted → contract emits event → `addProofOfObservationEvent` appends it → activity list refreshes.
+
+### PoO Task Flow Events (`pooTaskFlowEvents`)
+- Follows task flow rewards in `PoO_TaskFlow`.
+- Example flow: reward distributed → `addPooTaskFlowEvent` saves it → reward tab updates.
+
+### Genesis Block Faction Events (`genesisBlockFactionEvents`)
+- Stores events from `GenesisBlockFaction` (e.g., faction creation).
+- Example flow: new faction created → `addGenesisBlockFactionEvent` logs it → faction directory shows new entry.
+
+### Genesis Block Factory Events (`genesisBlockFactoryEvents`)
+- Records factory-related events from `GenesisBlockFactory`.
+- Example flow: faction factory deploys a contract → `addGenesisBlockFactoryEvent` records it → admin page shows the deployment.
+
+These slices allow the UI to react to live blockchain events and present an up‑to‑date activity log for each contract.

--- a/src/store/taskSlice.ts
+++ b/src/store/taskSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import type { TaskMetrics } from '../contracts/types';
-import { getTaskMetrics } from '../services/contractService';
+import { getTaskMetrics } from '../services/taskService';
 
 interface TaskState {
   tasks: any[];


### PR DESCRIPTION
## Summary
- Add README documenting each Redux store slice, its actions, triggers, and contract connections
- Introduce typed service modules for GovernanceToken, HouseOfTheLaw, and task metrics
- Update task slice to use new task service

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68927122dda4832a81c91be91547dd67