### PR TITLE
feat: add error handling, toast notifications, and loaders

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,47 +1,57 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Header from './components/Header';
-import Home from './pages/Home';
-import QuantumQuorist from './pages/QuantumQuorist';
-import QuantumCourse from './pages/QuantumCourse';
-import BlockchainBattalion from './pages/BlockchainBattalion';
-import BlockchainCourse from './pages/BlockchainCourse'; 
-import AIArchitect from './pages/AIArchitect';
-import AICourse from './pages/AICourse'; 
-import IoTInnovator from './pages/IoTInnovator';
-import IoTCourse from './pages/IoTCourse';
-import TaskManager from './sections/TaskManager';
-import DocumentSubmission from './sections/DocumentSubmission';
-import Feedback from './sections/Feedback';
-import Governance from './sections/Governance';
-import ProjectManagement from './sections/ProjectManagement';
-import TaskBuilder from './sections/TaskBuilder';
+import ErrorBoundary from './components/ErrorBoundary';
+import Loader from './components/Loader';
+import { ToastProvider } from './components/ToastProvider';
+
+const Home = lazy(() => import('./pages/Home'));
+const QuantumQuorist = lazy(() => import('./pages/QuantumQuorist'));
+const QuantumCourse = lazy(() => import('./pages/QuantumCourse'));
+const BlockchainBattalion = lazy(() => import('./pages/BlockchainBattalion'));
+const BlockchainCourse = lazy(() => import('./pages/BlockchainCourse'));
+const AIArchitect = lazy(() => import('./pages/AIArchitect'));
+const AICourse = lazy(() => import('./pages/AICourse'));
+const IoTInnovator = lazy(() => import('./pages/IoTInnovator'));
+const IoTCourse = lazy(() => import('./pages/IoTCourse'));
+const TaskManager = lazy(() => import('./sections/TaskManager'));
+const DocumentSubmission = lazy(() => import('./sections/DocumentSubmission'));
+const Feedback = lazy(() => import('./sections/Feedback'));
+const Governance = lazy(() => import('./sections/Governance'));
+const ProjectManagement = lazy(() => import('./sections/ProjectManagement'));
+const TaskBuilder = lazy(() => import('./sections/TaskBuilder'));
 import './App.css';
 
 const App = () => {
   return (
-    <Router>
-      <div className="app">
-        <Header />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/quantum-quorist" element={<QuantumQuorist />} />
-          <Route path="/quantum-quorist/course" element={<QuantumCourse />} />
-          <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
-          <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} /> 
-          <Route path="/ai-architect" element={<AIArchitect />} />
-          <Route path="/ai-architect/course" element={<AICourse />} />
-          <Route path="/iot-innovator" element={<IoTInnovator />} />
-          <Route path="/iot-innovator/course" element={<IoTCourse />} />
-          <Route path="/tasks" element={<TaskManager />} />
-          <Route path="/submit" element={<DocumentSubmission />} />
-          <Route path="/feedback" element={<Feedback />} />
-          <Route path="/governance" element={<Governance />} />
-          <Route path="/task-builder" element={<TaskBuilder />} />
-          <Route path="/projects" element={<ProjectManagement />} />
-        </Routes>
-      </div>
-    </Router>
+    <ErrorBoundary>
+      <ToastProvider>
+        <Router>
+          <div className="app">
+            <Header />
+            <Suspense fallback={<Loader />}>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/quantum-quorist" element={<QuantumQuorist />} />
+                <Route path="/quantum-quorist/course" element={<QuantumCourse />} />
+                <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
+                <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} />
+                <Route path="/ai-architect" element={<AIArchitect />} />
+                <Route path="/ai-architect/course" element={<AICourse />} />
+                <Route path="/iot-innovator" element={<IoTInnovator />} />
+                <Route path="/iot-innovator/course" element={<IoTCourse />} />
+                <Route path="/tasks" element={<TaskManager />} />
+                <Route path="/submit" element={<DocumentSubmission />} />
+                <Route path="/feedback" element={<Feedback />} />
+                <Route path="/governance" element={<Governance />} />
+                <Route path="/task-builder" element={<TaskBuilder />} />
+                <Route path="/projects" element={<ProjectManagement />} />
+              </Routes>
+            </Suspense>
+          </div>
+        </Router>
+      </ToastProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h2>Something went wrong.</h2>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+
+const Loader = () => (
+  <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+    <CircularProgress />
+  </Box>
+);
+
+export default Loader;

--- a/src/components/ToastProvider.js
+++ b/src/components/ToastProvider.js
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import MuiAlert from '@mui/material/Alert';
+
+const ToastContext = createContext({ showToast: () => {} });
+
+export const ToastProvider = ({ children }) => {
+  const [toast, setToast] = useState({ open: false, message: '', severity: 'info' });
+
+  const showToast = useCallback((message, severity = 'info') => {
+    setToast({ open: true, message, severity });
+  }, []);
+
+  const handleClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setToast((t) => ({ ...t, open: false }));
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Snackbar open={toast.open} autoHideDuration={4000} onClose={handleClose}>
+        <MuiAlert elevation={6} variant="filled" onClose={handleClose} severity={toast.severity} sx={{ width: '100%' }}>
+          {toast.message}
+        </MuiAlert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/src/sections/ProjectManagement/ProjectManagement.js
+++ b/src/sections/ProjectManagement/ProjectManagement.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import aiService from '../../services/aiService';
+import Loader from '../../components/Loader';
+import { useToast } from '../../components/ToastProvider';
 import './ProjectManagement.css';
 
 const ProjectManagement = () => {
@@ -7,6 +9,7 @@ const ProjectManagement = () => {
   const [newProject, setNewProject] = useState({ name: '', description: '', resources: '' });
   const [monitoringData, setMonitoringData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const { showToast } = useToast();
 
   useEffect(() => {
     const fetchMonitoringData = async () => {
@@ -16,6 +19,7 @@ const ProjectManagement = () => {
         setLoading(false);
       } catch (error) {
         console.error('Error fetching monitoring data:', error);
+        showToast('Failed to fetch monitoring data', 'error');
         setLoading(false);
       }
     };
@@ -35,8 +39,10 @@ const ProjectManagement = () => {
       const response = await aiService.allocateResources(newProject);
       setProjects([...projects, response.data]);
       setNewProject({ name: '', description: '', resources: '' });
+      showToast('Project added successfully', 'success');
     } catch (error) {
       console.error('Error adding project:', error);
+      showToast('Error adding project', 'error');
     }
   };
 
@@ -89,7 +95,7 @@ const ProjectManagement = () => {
       </div>
       <div className="monitoring-data">
         <h3>Project Monitoring</h3>
-        {loading ? <p>Loading monitoring data...</p> : (
+        {loading ? <Loader /> : (
           <ul>
             {monitoringData.map((data, index) => (
               <li key={index}>


### PR DESCRIPTION
## Summary
- add toast provider and error boundary components
- wrap routes with error handling, toasts, and loader fallbacks
- show toast feedback and loading indicator in project management section

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68928dd13a60832aabc2672fa5446b22