### PR TITLE
feat: add error handling, toasts, loaders, and contract auto-resolution

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,47 +1,57 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Header from './components/Header';
-import Home from './pages/Home';
-import QuantumQuorist from './pages/QuantumQuorist';
-import QuantumCourse from './pages/QuantumCourse';
-import BlockchainBattalion from './pages/BlockchainBattalion';
-import BlockchainCourse from './pages/BlockchainCourse'; 
-import AIArchitect from './pages/AIArchitect';
-import AICourse from './pages/AICourse'; 
-import IoTInnovator from './pages/IoTInnovator';
-import IoTCourse from './pages/IoTCourse';
-import TaskManager from './sections/TaskManager';
-import DocumentSubmission from './sections/DocumentSubmission';
-import Feedback from './sections/Feedback';
-import Governance from './sections/Governance';
-import ProjectManagement from './sections/ProjectManagement';
-import TaskBuilder from './sections/TaskBuilder';
+import ErrorBoundary from './components/ErrorBoundary';
+import Loader from './components/Loader';
+import { ToastProvider } from './components/ToastProvider';
+
+const Home = lazy(() => import('./pages/Home'));
+const QuantumQuorist = lazy(() => import('./pages/QuantumQuorist'));
+const QuantumCourse = lazy(() => import('./pages/QuantumCourse'));
+const BlockchainBattalion = lazy(() => import('./pages/BlockchainBattalion'));
+const BlockchainCourse = lazy(() => import('./pages/BlockchainCourse'));
+const AIArchitect = lazy(() => import('./pages/AIArchitect'));
+const AICourse = lazy(() => import('./pages/AICourse'));
+const IoTInnovator = lazy(() => import('./pages/IoTInnovator'));
+const IoTCourse = lazy(() => import('./pages/IoTCourse'));
+const TaskManager = lazy(() => import('./sections/TaskManager'));
+const DocumentSubmission = lazy(() => import('./sections/DocumentSubmission'));
+const Feedback = lazy(() => import('./sections/Feedback'));
+const Governance = lazy(() => import('./sections/Governance'));
+const ProjectManagement = lazy(() => import('./sections/ProjectManagement'));
+const TaskBuilder = lazy(() => import('./sections/TaskBuilder'));
 import './App.css';
 
 const App = () => {
   return (
-    <Router>
-      <div className="app">
-        <Header />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/quantum-quorist" element={<QuantumQuorist />} />
-          <Route path="/quantum-quorist/course" element={<QuantumCourse />} />
-          <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
-          <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} /> 
-          <Route path="/ai-architect" element={<AIArchitect />} />
-          <Route path="/ai-architect/course" element={<AICourse />} />
-          <Route path="/iot-innovator" element={<IoTInnovator />} />
-          <Route path="/iot-innovator/course" element={<IoTCourse />} />
-          <Route path="/tasks" element={<TaskManager />} />
-          <Route path="/submit" element={<DocumentSubmission />} />
-          <Route path="/feedback" element={<Feedback />} />
-          <Route path="/governance" element={<Governance />} />
-          <Route path="/task-builder" element={<TaskBuilder />} />
-          <Route path="/projects" element={<ProjectManagement />} />
-        </Routes>
-      </div>
-    </Router>
+    <ErrorBoundary>
+      <ToastProvider>
+        <Router>
+          <div className="app">
+            <Header />
+            <Suspense fallback={<Loader />}>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/quantum-quorist" element={<QuantumQuorist />} />
+                <Route path="/quantum-quorist/course" element={<QuantumCourse />} />
+                <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
+                <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} />
+                <Route path="/ai-architect" element={<AIArchitect />} />
+                <Route path="/ai-architect/course" element={<AICourse />} />
+                <Route path="/iot-innovator" element={<IoTInnovator />} />
+                <Route path="/iot-innovator/course" element={<IoTCourse />} />
+                <Route path="/tasks" element={<TaskManager />} />
+                <Route path="/submit" element={<DocumentSubmission />} />
+                <Route path="/feedback" element={<Feedback />} />
+                <Route path="/governance" element={<Governance />} />
+                <Route path="/task-builder" element={<TaskBuilder />} />
+                <Route path="/projects" element={<ProjectManagement />} />
+              </Routes>
+            </Suspense>
+          </div>
+        </Router>
+      </ToastProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h2>Something went wrong.</h2>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+
+const Loader = () => (
+  <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+    <CircularProgress />
+  </Box>
+);
+
+export default Loader;

--- a/src/components/ToastProvider.js
+++ b/src/components/ToastProvider.js
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import MuiAlert from '@mui/material/Alert';
+
+const ToastContext = createContext({ showToast: () => {} });
+
+export const ToastProvider = ({ children }) => {
+  const [toast, setToast] = useState({ open: false, message: '', severity: 'info' });
+
+  const showToast = useCallback((message, severity = 'info') => {
+    setToast({ open: true, message, severity });
+  }, []);
+
+  const handleClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setToast((t) => ({ ...t, open: false }));
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Snackbar open={toast.open} autoHideDuration={4000} onClose={handleClose}>
+        <MuiAlert elevation={6} variant="filled" onClose={handleClose} severity={toast.severity} sx={{ width: '100%' }}>
+          {toast.message}
+        </MuiAlert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/src/contracts/loadContract.ts
+++ b/src/contracts/loadContract.ts
@@ -1,27 +1,100 @@
-import { Contract, Signer, ethers } from 'ethers';
-import addresses from './metadata/addresses.json';
-import GovernanceToken from './metadata/GovernanceToken.json';
+import { Signer, providers } from 'ethers';
+import addressesJson from './metadata/addresses.json';
+import {
+  GovernanceToken,
+  FunctionalToken,
+  MpNSRegistry,
+  CrossFactionHub,
+  GTStaking,
+  HouseOfTheLaw,
+  ProofOfObservation,
+  PoO_TaskFlow,
+  GenesisBlockFaction,
+  GenesisBlockFactory,
+} from './metaverse';
 import { getProvider } from '../services/provider';
 
 type AddressBook = Record<string, Record<string, string>>;
-const abis: Record<string, any> = {
-  GovernanceToken: GovernanceToken.abi
+const addressBook: AddressBook = addressesJson as AddressBook;
+
+const contracts = {
+  GovernanceToken,
+  FunctionalToken,
+  MpNSRegistry,
+  CrossFactionHub,
+  GTStaking,
+  HouseOfTheLaw,
+  ProofOfObservation,
+  PoO_TaskFlow,
+  GenesisBlockFaction,
+  GenesisBlockFactory,
 };
 
-export async function loadContract(
-  name: keyof typeof abis,
-  signer?: Signer
-): Promise<Contract> {
-  const provider = signer?.provider ?? getProvider();
-  const network = await provider.getNetwork();
+export type ContractName = keyof typeof contracts;
+const envKeys: Record<ContractName, string> = {
+  GovernanceToken: 'GOVERNANCE_TOKEN',
+  FunctionalToken: 'FUNCTIONAL_TOKEN',
+  MpNSRegistry: 'MPNS_REGISTRY',
+  CrossFactionHub: 'CROSS_FACTION_HUB',
+  GTStaking: 'GT_STAKING',
+  HouseOfTheLaw: 'HOUSE_OF_THE_LAW',
+  ProofOfObservation: 'PROOF_OF_OBSERVATION',
+  PoO_TaskFlow: 'POO_TASK_FLOW',
+  GenesisBlockFaction: 'GENESIS_BLOCK_FACTION',
+  GenesisBlockFactory: 'GENESIS_BLOCK_FACTORY',
+};
 
-  const address = (addresses as AddressBook)[network.name]?.[name as string];
-  if (!address) {
-    throw new Error(`Address for ${String(name)} on network ${network.name} not found`);
+const registerAddress = (network: string, name: string, address: string) => {
+  addressBook[network] ??= {};
+  addressBook[network][name] = address;
+};
+
+async function resolveAddress(
+  name: ContractName,
+  provider: providers.Provider,
+): Promise<string> {
+  const network = await provider.getNetwork();
+  const cached = addressBook[network.name]?.[name];
+  if (cached) return cached;
+
+  const key = envKeys[name];
+  const fromEnv =
+    process.env[`REACT_APP_${key}_ADDRESS`] || process.env[`${key}_ADDRESS`];
+  if (fromEnv) {
+    registerAddress(network.name, name, fromEnv);
+    return fromEnv;
   }
 
-  const abi = abis[name as string];
-  return new ethers.Contract(address, abi, signer ?? provider);
+  const mpnsAddr =
+    process.env.REACT_APP_MPNS_REGISTRY_ADDRESS ||
+    process.env.MPNS_REGISTRY_ADDRESS;
+  if (mpnsAddr) {
+    const mpns = new MpNSRegistry(mpnsAddr, provider);
+    try {
+      const uri = await mpns.nameToUri(name);
+      const match = uri.match(/0x[a-fA-F0-9]{40}/);
+      if (match) {
+        registerAddress(network.name, name, match[0]);
+        return match[0];
+      }
+    } catch {
+      /* ignore lookup errors */
+    }
+  }
+
+  throw new Error(
+    `Address for ${String(name)} on network ${network.name} not found`,
+  );
+}
+
+export async function loadContract(
+  name: ContractName,
+  signer?: Signer,
+): Promise<any> {
+  const provider = signer?.provider ?? getProvider();
+  const address = await resolveAddress(name, provider);
+  const ContractCtor = contracts[name];
+  return new ContractCtor(address, signer ?? provider);
 }
 
 export default loadContract;

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -1,0 +1,11 @@
+import { useCallback } from 'react';
+import loadContract, { ContractName } from '../contracts/loadContract';
+import { getSigner } from '../services/provider';
+
+export const useContract = (name: ContractName, account?: string) =>
+  useCallback(async () => {
+    const signer = account ? await getSigner(account) : undefined;
+    return loadContract(name, signer);
+  }, [name, account]);
+
+export default useContract;

--- a/src/hooks/useFactionDeploy.ts
+++ b/src/hooks/useFactionDeploy.ts
@@ -1,26 +1,21 @@
 import { useState, useCallback } from 'react';
-import { GenesisBlockFactory } from '../contracts';
-import { getSigner } from '../services/provider';
+import useContract from './useContract';
 
 export const useFactionDeploy = (account?: string) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [factionAddress, setFactionAddress] = useState<string | null>(null);
 
+  const getFactory = useContract('GenesisBlockFactory', account);
+
   const deployFaction = useCallback(
     async (name: string) => {
       setLoading(true);
       setError(null);
       try {
-        const address =
-          process.env.REACT_APP_GENESIS_BLOCK_FACTORY_ADDRESS ||
-          process.env.GENESIS_BLOCK_FACTORY_ADDRESS ||
-          '0x0000000000000000000000000000000000000000';
-        const signer = await getSigner(account);
-        const factory = new GenesisBlockFactory(address, signer);
+        const factory = await getFactory();
         const tx = await factory.createFaction(name);
         const receipt = await tx.wait();
-        // the returned address is the first event arg or tx return
         const faction = (receipt?.events?.[0]?.args?.faction as string) || null;
         setFactionAddress(faction);
         return { tx, faction };
@@ -31,7 +26,7 @@ export const useFactionDeploy = (account?: string) => {
         setLoading(false);
       }
     },
-    [account],
+    [getFactory],
   );
 
   return { deployFaction, loading, error, factionAddress };

--- a/src/hooks/usePoOFlow.ts
+++ b/src/hooks/usePoOFlow.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback } from 'react';
-import { ProofOfObservation, PoO_TaskFlow } from '../contracts';
-import { getSigner } from '../services/provider';
+import useContract from './useContract';
 
 interface RewardParams {
   user: string;
@@ -16,23 +15,8 @@ export const usePoOFlow = (account?: string) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const getProofOfObservation = useCallback(async () => {
-    const address =
-      process.env.REACT_APP_PROOF_OF_OBSERVATION_ADDRESS ||
-      process.env.PROOF_OF_OBSERVATION_ADDRESS ||
-      '0x0000000000000000000000000000000000000000';
-    const signer = await getSigner(account);
-    return new ProofOfObservation(address, signer);
-  }, [account]);
-
-  const getPoOTaskFlow = useCallback(async () => {
-    const address =
-      process.env.REACT_APP_POO_TASK_FLOW_ADDRESS ||
-      process.env.POO_TASK_FLOW_ADDRESS ||
-      '0x0000000000000000000000000000000000000000';
-    const signer = await getSigner(account);
-    return new PoO_TaskFlow(address, signer);
-  }, [account]);
+  const getProofOfObservation = useContract('ProofOfObservation', account);
+  const getPoOTaskFlow = useContract('PoO_TaskFlow', account);
 
   const submitTask = useCallback(
     async (taskId: bigint, proof: string) => {

--- a/src/sections/ProjectManagement/ProjectManagement.js
+++ b/src/sections/ProjectManagement/ProjectManagement.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import aiService from '../../services/aiService';
+import Loader from '../../components/Loader';
+import { useToast } from '../../components/ToastProvider';
 import './ProjectManagement.css';
 
 const ProjectManagement = () => {
@@ -7,6 +9,7 @@ const ProjectManagement = () => {
   const [newProject, setNewProject] = useState({ name: '', description: '', resources: '' });
   const [monitoringData, setMonitoringData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const { showToast } = useToast();
 
   useEffect(() => {
     const fetchMonitoringData = async () => {
@@ -16,6 +19,7 @@ const ProjectManagement = () => {
         setLoading(false);
       } catch (error) {
         console.error('Error fetching monitoring data:', error);
+        showToast('Failed to fetch monitoring data', 'error');
         setLoading(false);
       }
     };
@@ -35,8 +39,10 @@ const ProjectManagement = () => {
       const response = await aiService.allocateResources(newProject);
       setProjects([...projects, response.data]);
       setNewProject({ name: '', description: '', resources: '' });
+      showToast('Project added successfully', 'success');
     } catch (error) {
       console.error('Error adding project:', error);
+      showToast('Error adding project', 'error');
     }
   };
 
@@ -89,7 +95,7 @@ const ProjectManagement = () => {
       </div>
       <div className="monitoring-data">
         <h3>Project Monitoring</h3>
-        {loading ? <p>Loading monitoring data...</p> : (
+        {loading ? <Loader /> : (
           <ul>
             {monitoringData.map((data, index) => (
               <li key={index}>


### PR DESCRIPTION
## Summary
- add toast provider and error boundary components
- wrap routes with error handling, toasts, and loader fallbacks
- show toast feedback and loading indicator in project management section
- auto-resolve contracts by name via MpNS and expose reusable hook

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68928dd13a60832aabc2672fa5446b22