### PR TITLE
Add AI-driven middleware for task recommendations

### DIFF
--- a/src/store/aiMiddleware.js
+++ b/src/store/aiMiddleware.js
@@ -1,0 +1,35 @@
+import aiService from '../services/aiService';
+import { setRecommendations, setProposals, setStatus } from './aiSlice';
+import { setTasks, setCurrentTask, fetchTaskMetrics } from './taskSlice';
+
+const aiMiddleware = (store) => (next) => async (action) => {
+  const result = next(action);
+
+  if (
+    setTasks.match(action) ||
+    setCurrentTask.match(action) ||
+    fetchTaskMetrics.fulfilled.match(action)
+  ) {
+    const { tasks, currentTask, metrics } = store.getState().task;
+
+    try {
+      const response = await aiService.proposeTasks({ tasks, currentTask, metrics });
+
+      if (response?.recommendations) {
+        store.dispatch(setRecommendations(response.recommendations));
+      }
+      if (response?.proposals) {
+        store.dispatch(setProposals(response.proposals));
+      }
+      if (response?.status) {
+        store.dispatch(setStatus(response.status));
+      }
+    } catch (err) {
+      console.error('AI service call failed', err);
+    }
+  }
+
+  return result;
+};
+
+export default aiMiddleware;

--- a/src/store/aiSlice.js
+++ b/src/store/aiSlice.js
@@ -2,6 +2,8 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   recommendations: [],
+  proposals: [],
+  status: null,
 };
 
 const aiSlice = createSlice({
@@ -11,8 +13,14 @@ const aiSlice = createSlice({
     setRecommendations(state, action) {
       state.recommendations = action.payload;
     },
+    setProposals(state, action) {
+      state.proposals = action.payload;
+    },
+    setStatus(state, action) {
+      state.status = action.payload;
+    },
   },
 });
 
-export const { setRecommendations } = aiSlice.actions;
+export const { setRecommendations, setProposals, setStatus } = aiSlice.actions;
 export default aiSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import gtReducer from './gtSlice';
 import taskReducer from './taskSlice';
 import aiReducer from './aiSlice';
+import aiMiddleware from './aiMiddleware';
 import {
   governanceTokenEventsReducer,
   functionalTokenEventsReducer,
@@ -31,4 +32,6 @@ export const store = configureStore({
     genesisBlockFactionEvents: genesisBlockFactionEventsReducer,
     genesisBlockFactoryEvents: genesisBlockFactoryEventsReducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(aiMiddleware),
 });


### PR DESCRIPTION
## Summary
- add AI middleware that reacts to task-related actions and consults `aiService`
- extend AI slice with proposal and status handling
- wire middleware into Redux store configuration

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689297462d54832aa32157f011a9fa8a