### PR TITLE
feat: add task observations and proposals to AI slice

### DIFF
--- a/src/store/aiMiddleware.js
+++ b/src/store/aiMiddleware.js
@@ -1,5 +1,10 @@
 import aiService from '../services/aiService';
-import { setRecommendations, setProposals, setStatus } from './aiSlice';
+import {
+  setRecommendations,
+  setProposals,
+  setTaskObservations,
+  setStatus,
+} from './aiSlice';
 import { setTasks, setCurrentTask, fetchTaskMetrics } from './taskSlice';
 
 const aiMiddleware = (store) => (next) => async (action) => {
@@ -20,6 +25,9 @@ const aiMiddleware = (store) => (next) => async (action) => {
       }
       if (response?.proposals) {
         store.dispatch(setProposals(response.proposals));
+      }
+      if (response?.taskObservations) {
+        store.dispatch(setTaskObservations(response.taskObservations));
       }
       if (response?.status) {
         store.dispatch(setStatus(response.status));

--- a/src/store/aiSlice.js
+++ b/src/store/aiSlice.js
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const initialState = {
   recommendations: [],
   proposals: [],
+  taskObservations: [],
   status: null,
 };
 
@@ -16,11 +17,19 @@ const aiSlice = createSlice({
     setProposals(state, action) {
       state.proposals = action.payload;
     },
+    setTaskObservations(state, action) {
+      state.taskObservations = action.payload;
+    },
     setStatus(state, action) {
       state.status = action.payload;
     },
   },
 });
 
-export const { setRecommendations, setProposals, setStatus } = aiSlice.actions;
+export const {
+  setRecommendations,
+  setProposals,
+  setTaskObservations,
+  setStatus,
+} = aiSlice.actions;
 export default aiSlice.reducer;


### PR DESCRIPTION
## Summary
- track proposals and task observations in AI slice
- update middleware to dispatch task observation updates

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68929abac154832aa427c3ad28f30912