### PR TITLE
feat: add proposal creator component

### DIFF
--- a/src/components/law/ProposalCreator.tsx
+++ b/src/components/law/ProposalCreator.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import useCreateProposal from '../../hooks/useCreateProposal';
+
+const ProposalCreator: React.FC = () => {
+  const isValidated = useSelector((state: any) => state.ai?.status === 'validated');
+  const { createProposal, loading, error, success } = useCreateProposal();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [executionData, setExecutionData] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createProposal({ title, description, executionData });
+      setTitle('');
+      setDescription('');
+      setExecutionData('');
+    } catch (err) {
+      // errors handled in hook
+    }
+  };
+
+  if (!isValidated) {
+    return <div className="text-gray-500">AI assistant validation required to create proposals.</div>;
+  }
+
+  return (
+    <div className="p-4 border rounded">
+      <h2 className="text-xl mb-4">Create Proposal</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+          className="w-full p-2 border rounded"
+        />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          required
+          className="w-full p-2 border rounded"
+        />
+        <textarea
+          value={executionData}
+          onChange={(e) => setExecutionData(e.target.value)}
+          placeholder="Execution Data"
+          required
+          className="w-full p-2 border rounded"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          {loading ? 'Submitting...' : 'Submit Proposal'}
+        </button>
+      </form>
+      {error && <div className="text-red-500 mt-2">{error.message || 'Submission failed'}</div>}
+      {success && <div className="text-green-500 mt-2">Proposal submitted successfully!</div>}
+    </div>
+  );
+};
+
+export default ProposalCreator;

--- a/src/hooks/useCreateProposal.ts
+++ b/src/hooks/useCreateProposal.ts
@@ -1,0 +1,42 @@
+import { useState, useCallback } from 'react';
+import { createProposal as serviceCreateProposal } from '../services/houseOfTheLawService';
+
+interface CreateProposalArgs {
+  title: string;
+  description: string;
+  executionData: string;
+}
+
+export const useCreateProposal = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const createProposal = useCallback(
+    async ({ title, description, executionData }: CreateProposalArgs) => {
+      setLoading(true);
+      setError(null);
+      setSuccess(false);
+      try {
+        await serviceCreateProposal({
+          description,
+          ipfsHash: '',
+          eligibleGTId: 0,
+          target: '0x0000000000000000000000000000000000000000',
+          data: executionData,
+        });
+        setSuccess(true);
+      } catch (err: any) {
+        setError(err);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  return { createProposal, loading, error, success };
+};
+
+export default useCreateProposal;


### PR DESCRIPTION
## Summary
- add law proposal creator component gated by AI validation
- implement `useCreateProposal` hook to submit proposals and show feedback

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892bc73d590832a81a65b58e98a0d87