### PR TITLE
Add TaskMetricsCard component

### DIFF
--- a/src/components/tasks/TaskBrowser.tsx
+++ b/src/components/tasks/TaskBrowser.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchTaskMetrics, setCurrentTask } from '../../store/taskSlice';
 import taskService from '../../services/taskService';
 import usePoOFlow from '../../hooks/usePoOFlow';
+import TaskMetricsCard from './TaskMetricsCard';
 
 interface Task {
   id: number;
@@ -99,8 +100,16 @@ const TaskBrowser: React.FC<TaskBrowserProps> = ({ userAddress }) => {
               key={task.id}
               className="flex items-center justify-between border p-2 rounded"
             >
-              <div>
-                <h3 className="font-semibold">{task.title || `Task #${task.id}`}</h3>
+              <div className="flex-1 mr-4">
+                <h3 className="font-semibold mb-2">
+                  {task.title || `Task #${task.id}`}
+                </h3>
+                {metrics[task.id] && (
+                  <TaskMetricsCard
+                    progress={Number((metrics[task.id] as any).progress ?? (metrics[task.id] as any).demand ?? 0)}
+                    reward={Number((metrics[task.id] as any).reward ?? (metrics[task.id] as any).supply ?? 0)}
+                  />
+                )}
               </div>
               {!completed.has(task.id) && (
                 <button

--- a/src/components/tasks/TaskMetricsCard.tsx
+++ b/src/components/tasks/TaskMetricsCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface TaskMetricsCardProps {
+  progress: number;
+  reward: number | string;
+}
+
+const TaskMetricsCard: React.FC<TaskMetricsCardProps> = ({ progress, reward }) => {
+  const clampedProgress = Math.min(Math.max(progress, 0), 100);
+  return (
+    <div className="p-2 border rounded bg-white shadow-sm">
+      <div className="mb-2 flex justify-between items-center">
+        <span className="text-sm font-semibold">Progress</span>
+        <span className="text-xs">{clampedProgress}%</span>
+      </div>
+      <div className="w-full bg-gray-200 rounded h-2 mb-2">
+        <div
+          className="bg-green-500 h-2 rounded"
+          style={{ width: `${clampedProgress}%` }}
+        />
+      </div>
+      <div className="flex justify-between items-center text-sm">
+        <span className="font-semibold">Reward</span>
+        <span>{reward}</span>
+      </div>
+    </div>
+  );
+};
+
+export default TaskMetricsCard;


### PR DESCRIPTION
## Summary
- add TaskMetricsCard component to show task progress and rewards
- display metrics within TaskBrowser using reusable card

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '../../hooks/useStakeGT', BigInt literals not available)*

------
https://chatgpt.com/codex/tasks/task_e_6892c8f87bf4832a863c6cd8518d71c6