### PR TITLE
feat: add AI assistant console

### DIFF
--- a/src/components/ai/AiAssistantConsole.tsx
+++ b/src/components/ai/AiAssistantConsole.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import useAiRecommendations from '../../hooks/useAiRecommendations';
+
+interface RootState {
+  gt: {
+    staked: Record<number, number>;
+  };
+}
+
+const STAKE_THRESHOLD = 10;
+
+const AiAssistantConsole: React.FC = () => {
+  const staked = useSelector((state: RootState) => state.gt.staked[0] || 0);
+  const { recommendations, status } = useAiRecommendations();
+
+  if (staked < STAKE_THRESHOLD) {
+    return null;
+  }
+
+  const handleCreateProposal = () => {
+    console.log('Initiate proposal creation');
+  };
+
+  const handleStartTask = () => {
+    console.log('Initiate task');
+  };
+
+  return (
+    <div className="p-4 border rounded shadow-md">
+      <h3 className="text-xl mb-4">AI Assistant</h3>
+      {status === 'loading' && <p className="text-gray-500">Loading recommendations...</p>}
+      {status === 'error' && <p className="text-red-500">Failed to load recommendations</p>}
+      {recommendations.length > 0 && (
+        <ul className="mb-4 list-disc list-inside">
+          {recommendations.map((rec: any, idx: number) => (
+            <li key={idx}>{rec.title || rec}</li>
+          ))}
+        </ul>
+      )}
+      <div className="flex space-x-2">
+        <button
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+          onClick={handleCreateProposal}
+        >
+          Create Proposal
+        </button>
+        <button
+          className="bg-green-500 text-white px-4 py-2 rounded"
+          onClick={handleStartTask}
+        >
+          Start Task
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AiAssistantConsole;

--- a/src/hooks/useAiRecommendations.ts
+++ b/src/hooks/useAiRecommendations.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import aiService from '../services/aiService';
+import { setRecommendations, setStatus } from '../store/aiSlice';
+
+interface RootState {
+  ai: {
+    recommendations: any[];
+    status: string | null;
+  };
+}
+
+const useAiRecommendations = () => {
+  const dispatch = useDispatch();
+  const recommendations = useSelector((state: RootState) => state.ai.recommendations);
+  const status = useSelector((state: RootState) => state.ai.status);
+
+  useEffect(() => {
+    const fetchRecommendations = async () => {
+      dispatch(setStatus('loading'));
+      try {
+        const result = await aiService.recommendProposals({});
+        dispatch(setRecommendations(result.proposals || []));
+        dispatch(setStatus('ready'));
+      } catch (err) {
+        console.error('Failed to fetch AI recommendations', err);
+        dispatch(setStatus('error'));
+      }
+    };
+
+    if (status === null) {
+      fetchRecommendations();
+    }
+  }, [dispatch, status]);
+
+  return { recommendations, status };
+};
+
+export default useAiRecommendations;


### PR DESCRIPTION
## Summary
- add AI assistant console gating access by staked GT amount
- implement hook to load AI recommendations from service

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6892dbfeb070832aaa5ece7f8b05721f