### PR TITLE
docs: add architecture readmes

### DIFF
--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -1,0 +1,29 @@
+# UI Architecture Overview
+
+The frontend is built with React and Redux Toolkit and integrates with Ethereum smart contracts and OpenAI services. This document summarizes how the main pieces fit together.
+
+## Pages
+Top-level routes under `src/pages/` render faction profiles and course curricula along with the landing page. Pages are mostly static and compose reusable UI components. They do not talk directly to Redux or blockchain services but can be enhanced to do so.
+
+## Components
+Reusable widgets under `src/components/` handle presentation and user interactions. Some notable categories:
+- **Shared**: generic UI pieces such as modal and wallet connector.
+- **Domain-specific**: AI consoles, staking panels, faction tools, and governance voting components.
+These components interact with Redux slices like `gt`, `task`, and `ai` and call services for smart contract or AI operations.
+
+## Services
+Modules in `src/services/` abstract side effects. Examples include:
+- **aiService** for OpenAI calls invoked via `aiMiddleware`.
+- **gtService** and **houseOfTheLawService** for contract interactions.
+- **eventListeners** which push blockchain events into Redux.
+They provide a thin layer between UI logic and external systems, keeping components focused on rendering.
+
+## Redux Store
+Slices in `src/store/` manage application state for wallets, tasks, governance tokens, AI recommendations, and blockchain events. Middleware connects services to slices so components can dispatch actions without handling side effects directly.
+
+## Extension Points
+- Add new slices and services for emerging features.
+- Replace placeholder APIs in services with production endpoints.
+- Enhance pages to fetch data dynamically and persist progress.
+- Introduce additional components under existing folders to expand domain capabilities.
+

--- a/src/pages/README.md
+++ b/src/pages/README.md
@@ -1,0 +1,58 @@
+# Pages Overview
+
+These React components represent top-level routes in the application. Each entry explains what the page presents, whether it ties into Redux or external systems, and how it can be expanded.
+
+## Home.js
+- **Purpose:** Landing page composing hero, feature, and testimonial sections.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none directly, though child components may use services.
+- **Extension points:** Load content from APIs or conditionally render sections based on store state.
+
+## AIArchitect.js
+- **Purpose:** Faction page describing the AI Architect group and linking to its course.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Pull charter and mission text from IPFS or a CMS.
+
+## AICourse.js
+- **Purpose:** Static curriculum overview for the AI Architect course.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Replace hardcoded modules with dynamic lesson data.
+
+## BlockchainBattalion.js
+- **Purpose:** Faction page highlighting blockchain research initiatives.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Inject real proposal data or integrate voting widgets.
+
+## BlockchainCourse.js
+- **Purpose:** Course outline for Blockchain Battalion training.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Fetch modules from an education API or track progress in Redux.
+
+## IoTInnovator.js
+- **Purpose:** Faction page focused on Internet of Things initiatives.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Surface live device statistics or member contributions.
+
+## IoTCourse.js
+- **Purpose:** Curriculum details for the IoT Innovator course.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Add enrollment forms or fetch lesson content.
+
+## QuantumQuorist.js
+- **Purpose:** Faction page dedicated to quantum computing pursuits.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Integrate with governance proposals or show dynamic document links.
+
+## QuantumCourse.js
+- **Purpose:** Course page summarizing the Quantum Quorist curriculum.
+- **Redux slices:** none.
+- **Smart contracts or AI:** none.
+- **Extension points:** Allow progress tracking or interactive simulations.
+

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,58 @@
+# Services Overview
+
+This directory contains helper modules that encapsulate API calls, smart contract interactions, and other side-effect logic. Each service entry below outlines its purpose, Redux slice connections, reliance on smart contracts or AI, and areas where functionality can be extended.
+
+## aiService.js
+- **Purpose:** Wrapper around OpenAI APIs to initialize agents, propose tasks, recommend proposals, optimize documents, and observe task metrics.
+- **Redux slices:** Used by `aiMiddleware` which dispatches to the `ai` slice.
+- **Smart contracts or AI:** Calls the OpenAI API (AI interactions only).
+- **Extension points:** Support additional AI endpoints or fine-tune parameters such as model or temperature.
+
+## blockchainService.js
+- **Purpose:** Utility for governance token operations and IPFS metadata handling.
+- **Redux slices:** none.
+- **Smart contracts or AI:** Reads/writes `GovernanceToken` contract and can forward messages to an AI agent.
+- **Extension points:** Add more contract helpers or replace the placeholder IPFS/AI endpoints.
+
+## eventListeners.ts
+- **Purpose:** Subscribes to blockchain events and dispatches them into Redux.
+- **Redux slices:** Dispatches `add*Event` actions in `eventSlices`.
+- **Smart contracts or AI:** Listens to numerous on-chain contracts.
+- **Extension points:** Filter events, debounce dispatches, or persist events to storage.
+
+## gtService.ts
+- **Purpose:** Convenience methods for staking and querying governance tokens.
+- **Redux slices:** none.
+- **Smart contracts or AI:** Interacts with `GovernanceToken` and `GTStaking` contracts.
+- **Extension points:** Expose additional staking utilities or integrate gas estimations.
+
+## hashUtils.js
+- **Purpose:** Creates SHA-256 hashes and links metadata with on-chain governance tokens.
+- **Redux slices:** none.
+- **Smart contracts or AI:** Uses `blockchainService` to mint tokens and retrieve metadata from IPFS.
+- **Extension points:** Support alternative hash algorithms or metadata storage backends.
+
+## houseOfTheLawService.ts
+- **Purpose:** Facilitates proposal creation, voting, and task validation in the House of the Law.
+- **Redux slices:** none.
+- **Smart contracts or AI:** Calls the `HouseOfTheLaw` smart contract.
+- **Extension points:** Handle proposal status polling or enhanced error handling.
+
+## ipfsService.js
+- **Purpose:** Uploads files to IPFS and returns their content hash.
+- **Redux slices:** none.
+- **Smart contracts or AI:** Communicates with an IPFS HTTP API only.
+- **Extension points:** Add download helpers or switch to authenticated gateways.
+
+## provider.js
+- **Purpose:** Provides a shared ethers provider and signer for blockchain operations.
+- **Redux slices:** none.
+- **Smart contracts or AI:** Connects to Ethereum networks.
+- **Extension points:** Support multiple networks or fallback providers.
+
+## taskService.ts
+- **Purpose:** Reads task metrics and exposes the GT staking contract.
+- **Redux slices:** Used by `taskSlice` through the `fetchTaskMetrics` thunk.
+- **Smart contracts or AI:** Calls the `GTStaking` contract.
+- **Extension points:** Add caching controls or task mutation helpers.
+


### PR DESCRIPTION
## Summary
- document services layer with Redux and smart contract links
- outline top-level pages and extension ideas
- add UI architecture overview for quick navigation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6893b23334ac832aba244db2af47a362