### PR TITLE
docs: add terms of participation and update tokenomics

### DIFF
--- a/docs/tokenomics.md
+++ b/docs/tokenomics.md
@@ -5,17 +5,32 @@ sidebar_position: 2
 
 # Tokenomics
 
-Overview of the platform's dual-token economy and reward mechanisms.
+Overview of the platform's dual-token economy, staking mechanisms, and reward flows.
 
 ## Dual-Token Model
 
-Placeholder for governance token (GT) and functional token (FT) logic.
+The platform issues a Governance Token (GT) and a Functional Token (FT).
+GT powers governance and long-term incentives, while FT is used for in-world utility such as AI console access and task payments.
+
+## Staking
+
+Users stake GT to gain voting power and unlock higher reward tiers.
+Staked tokens are subject to lockup periods and can earn additional GT as staking rewards.
+Early withdrawal forfeits pending rewards.
 
 ## Proof of Observation
 
-Placeholder for description of the Proof of Observation mechanism.
+User-submitted tasks are validated through the Proof of Observation (PoO) mechanism.
+Validated contributions mint FT to the participant and may grant GT bonuses for sustained engagement.
 
-## Rewards
+## AI Console Gating
 
-Placeholder for reward distribution details.
+Access to the AI console requires holding or staking a minimum FT balance.
+Usage consumes FT credits; additional staking enables extended or higher-priority access.
 
+## Task Reward Flows
+
+1. A participant completes a task and submits results to PoO.
+2. Validators confirm the task and signal reward distribution.
+3. FT rewards are minted to the participant; a portion may be routed to staking pools.
+4. GT bonuses are issued to stakers who support governance or validation efforts.

--- a/terms-of-participation.md
+++ b/terms-of-participation.md
@@ -1,0 +1,30 @@
+# Terms of Participation
+
+Participants in the platform agree to the following principles when earning Governance Tokens (GT) and Functional Tokens (FT):
+
+## Eligibility and Conduct
+- Only complete and verifiable tasks are eligible for token rewards.
+- Participants must provide accurate information and respect community guidelines.
+- Fraudulent activity or manipulation of task metrics results in forfeiture of rewards.
+
+## Governance and Voting
+- GT holders may submit and vote on proposals that shape platform policies and upgrades.
+- Each staked GT contributes to voting power; unstaked GT does not grant governance rights.
+- Votes are final once recorded on-chain and may carry staking penalties for malicious behavior.
+
+## Staking Requirements
+- Staking GT is required to access governance features and higher reward tiers.
+- Staked tokens are subject to lockup periods defined by governance.
+- Early withdrawal during lockup forfeits any pending rewards.
+
+## Reward Distribution
+- FT is distributed for successfully completed tasks validated by Proof of Observation.
+- GT rewards are issued for long-term contributions such as staking and governance participation.
+- Rewards may be adjusted or revoked for violations of these terms.
+
+## AI Console Access
+- Access to the AI console requires holding or staking a minimum amount of FT.
+- Heavy usage of the console consumes FT credits; additional staking may be required for extended sessions.
+- Abuse of the console, including attempts to bypass staking gates, may result in suspension of access.
+
+By participating in the platform, users acknowledge that they have read and agree to these terms.


### PR DESCRIPTION
## Summary
- add terms-of-participation document outlining user rules for GT/FT
- expand tokenomics to cover staking, AI console gating, and task rewards

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6893bc14db9c832ab779a954702b1c5a