### PR TITLE
chore: configure hardhat upgrades

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config';
+import '@openzeppelin/hardhat-upgrades';
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 
@@ -8,7 +10,14 @@ const config: HardhatUserConfig = {
     tests: './test',
     cache: './cache',
     artifacts: './artifacts'
-  }
+  },
+  networks: {
+    sepolia: {
+      url: process.env.SEPOLIA_RPC_URL || '',
+      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : []
+    }
+  },
+  etherscan: { apiKey: process.env.ETHERSCAN_API_KEY }
 };
 
 export default config;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -14,6 +14,9 @@
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "hardhat": "^2.20.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "@openzeppelin/hardhat-upgrades": "^3.0.0",
+    "@nomicfoundation/hardhat-ethers": "^3.0.6",
+    "@nomicfoundation/hardhat-verify": "^2.0.14"
   }
 }


### PR DESCRIPTION
## Summary
- add hardhat upgrades plugin and peer dependencies
- configure sepolia network and etherscan api key for hardhat

## Testing
- `npx hardhat test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6893eaaa2448832a8c15c0d53216d500