### PR TITLE
feat: add deployment initializer script

### DIFF
--- a/contracts/scripts/deploy/00_initialize.ts
+++ b/contracts/scripts/deploy/00_initialize.ts
@@ -1,0 +1,14 @@
+import 'dotenv/config';
+import { ethers, network } from 'hardhat';
+import fs from 'fs'; import path from 'path';
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log(`Deployer: ${deployer.address} on ${network.name}`);
+
+  const dir = path.join(__dirname, '..', 'deployments');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${network.name}.json`);
+  if (!fs.existsSync(file)) fs.writeFileSync(file, '{}');
+}
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add deployment initialization script for Hardhat to record deployer address and create empty network deployment file

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6893f42a2954832a82b0309ffd903cdc