### PR TITLE
feat: add post deployment script

### DIFF
--- a/contracts/scripts/post-deploy.ts
+++ b/contracts/scripts/post-deploy.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { ethers, network } from 'hardhat';
+import fs from 'fs'; import path from 'path';
+
+const file = path.join(__dirname, '..', 'deployments', `${network.name}.json`);
+const d = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file,'utf8')) : {};
+
+async function main() {
+  const ft = await ethers.getContractAt('FunctionalToken', d.FunctionalToken);
+  const house = await ethers.getContractAt('HouseOfTheLaw', d.HouseOfTheLaw);
+  const taskFlow = await ethers.getContractAt('PoO_TaskFlow', d.PoO_TaskFlow);
+  const poo = await ethers.getContractAt('ProofOfObservation', d.ProofOfObservation);
+
+  const minter = await ft.MINTER_ROLE();
+  if (!(await ft.hasRole(minter, d.HouseOfTheLaw))) {
+    await (await ft.grantRole(minter, d.HouseOfTheLaw)).wait();
+    console.log('Granted MINTER_ROLE to HouseOfTheLaw');
+  }
+  if (!(await ft.hasRole(minter, d.PoO_TaskFlow))) {
+    await (await ft.grantRole(minter, d.PoO_TaskFlow)).wait();
+    console.log('Granted MINTER_ROLE to PoO_TaskFlow');
+  }
+  if ((await house.proofOfObservation()) !== d.ProofOfObservation) {
+    await (await house.setProofOfObservation(d.ProofOfObservation)).wait();
+    console.log('Linked ProofOfObservation to HouseOfTheLaw');
+  }
+}
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add post-deployment script to grant minter roles and connect ProofOfObservation

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build` (fails: hardhat not found)
- `npm install` (fails: unable to resolve dependency tree)


------
https://chatgpt.com/codex/tasks/task_e_689417b3bd1c832aab2ba8c8eb1a5970