### PR TITLE
Add MpNS resolution hook and ABI

### DIFF
--- a/src/abis/MpNSRegistry.json
+++ b/src/abis/MpNSRegistry.json
@@ -1,0 +1,18 @@
+[
+  "function initialize()",
+  "function register(string name,address owner,uint256 duration,string uri)",
+  "function updateURI(string name,string newUri)",
+  "function transfer(string name,address newOwner)",
+  "function freezeName(string name)",
+  "function ownerOf(string name) view returns (address)",
+  "function expirationOf(string name) view returns (uint256)",
+  "function nameToUri(string name) view returns (string)",
+  "function isFrozen(string name) view returns (bool)",
+  "function grantRole(bytes32 role,address account)",
+  "function revokeRole(bytes32 role,address account)",
+  "function hasRole(bytes32 role,address account) view returns (bool)",
+  "event NameRegistered(string indexed name,address indexed owner,uint256 expiration,string uri)",
+  "event URIUpdated(string indexed name,string oldUri,string newUri)",
+  "event NameTransferred(string indexed name,address indexed oldOwner,address indexed newOwner)",
+  "event NameFrozen(string indexed name)"
+]

--- a/src/hooks/useMpns.ts
+++ b/src/hooks/useMpns.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+import { getProvider } from '../services/provider';
+import MpNSRegistryAbi from '../abis/MpNSRegistry.json';
+
+export type MpnsResolution = {
+  type: 'contract' | 'ipfs' | 'empty';
+  value: string;
+};
+
+export const useMpns = (name?: string) => {
+  const [result, setResult] = useState<MpnsResolution>({
+    type: 'empty',
+    value: '',
+  });
+
+  const provider = getProvider();
+  const registryAddress =
+    process.env.REACT_APP_MPNS_REGISTRY_ADDRESS ||
+    process.env.MPNS_REGISTRY_ADDRESS;
+
+  const resolve = useCallback(
+    async (lookup: string): Promise<MpnsResolution> => {
+      if (!registryAddress || !lookup) {
+        const empty: MpnsResolution = { type: 'empty', value: '' };
+        setResult(empty);
+        return empty;
+      }
+      try {
+        const registry = new ethers.Contract(
+          registryAddress,
+          MpNSRegistryAbi,
+          provider,
+        );
+        const uri: string = await registry.nameToUri(lookup);
+        let res: MpnsResolution;
+        if (!uri) {
+          res = { type: 'empty', value: '' };
+        } else if (/^0x[a-fA-F0-9]{40}$/.test(uri)) {
+          res = { type: 'contract', value: uri };
+        } else if (uri.startsWith('ipfs://') || uri.includes('/ipfs/')) {
+          res = { type: 'ipfs', value: uri };
+        } else {
+          res = { type: 'empty', value: uri };
+        }
+        setResult(res);
+        return res;
+      } catch {
+        const empty: MpnsResolution = { type: 'empty', value: '' };
+        setResult(empty);
+        return empty;
+      }
+    },
+    [registryAddress, provider],
+  );
+
+  useEffect(() => {
+    if (name) {
+      resolve(name);
+    } else {
+      setResult({ type: 'empty', value: '' });
+    }
+  }, [name, resolve]);
+
+  return { result, resolve };
+};
+
+export default useMpns;


### PR DESCRIPTION
## Summary
- add MpNSRegistry ABI
- implement useMpns hook to resolve MpNS names to contract, IPFS, or empty

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68942a51b044832ab08fa51c5cc8efc2