### PR TITLE
Add House of Code tasks page via Mpns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ const AIArchitect = lazy(() => import('./pages/AIArchitect'));
 const AICourse = lazy(() => import('./pages/AICourse'));
 const IoTInnovator = lazy(() => import('./pages/IoTInnovator'));
 const IoTCourse = lazy(() => import('./pages/IoTCourse'));
+const HouseOfCodeTasks = lazy(() => import('./pages/HouseOfCode/tasks'));
 const TaskManager = lazy(() => import('./sections/TaskManager'));
 const DocumentSubmission = lazy(() => import('./sections/DocumentSubmission'));
 const Feedback = lazy(() => import('./sections/Feedback'));
@@ -40,6 +41,7 @@ const App = () => {
                 <Route path="/ai-architect/course" element={<AICourse />} />
                 <Route path="/iot-innovator" element={<IoTInnovator />} />
                 <Route path="/iot-innovator/course" element={<IoTCourse />} />
+                <Route path="/house-of-code/tasks" element={<HouseOfCodeTasks />} />
                 <Route path="/tasks" element={<TaskManager />} />
                 <Route path="/submit" element={<DocumentSubmission />} />
                 <Route path="/feedback" element={<Feedback />} />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -18,6 +18,7 @@ const Header = () => {
         <Link to="/feedback">Feedback</Link>
         <Link to="/governance">Governance</Link>
         <Link to="/projects">Projects</Link>
+        <Link to="/house-of-code/tasks">House of Code Tasks</Link>
       </nav>
       <button className="toggle-button" onClick={toggleNav}>
         {isNavVisible ? '<<' : '>>'}

--- a/src/pages/HouseOfCode/tasks.tsx
+++ b/src/pages/HouseOfCode/tasks.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import useMpns from '../../hooks/useMpns';
+
+interface Task {
+  title?: string;
+  [key: string]: any;
+}
+
+const HouseOfCodeTasks: React.FC = () => {
+  const { result } = useMpns('houseOfCode.tasks.level1.mpns');
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (result.type === 'ipfs' && result.value) {
+        let url = result.value;
+        if (url.startsWith('ipfs://')) {
+          url = `https://ipfs.io/ipfs/${url.slice(7)}`;
+        }
+        try {
+          const resp = await fetch(url);
+          const data = await resp.json();
+          if (Array.isArray(data)) {
+            setTasks(data);
+          } else if (Array.isArray(data.tasks)) {
+            setTasks(data.tasks);
+          }
+        } catch (err) {
+          console.error('Failed to load tasks', err);
+        }
+      }
+    };
+    load();
+  }, [result]);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">House of Code Tasks</h1>
+      {tasks.length === 0 ? (
+        <div>No tasks found.</div>
+      ) : (
+        <ul className="list-disc pl-5 space-y-2">
+          {tasks.map((task, idx) => (
+            <li key={idx}>{task.title || `Task ${idx + 1}`}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default HouseOfCodeTasks;
+


### PR DESCRIPTION
## Summary
- add House of Code tasks page that resolves tasks via Mpns and renders titles from IPFS
- register House of Code tasks page in router
- expose navigation link to House of Code tasks page

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68942e712e48832aa388eb3178460a34