### PR TITLE
feat: add governance token validation

### DIFF
--- a/src/components/law/ProposalCreator.tsx
+++ b/src/components/law/ProposalCreator.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useCreateProposal from '../../hooks/useCreateProposal';
+import useGtValidation from '../../hooks/useGtValidation';
 
 const ProposalCreator: React.FC = () => {
   const isValidated = useSelector((state: any) => state.ai?.status === 'validated');
+  const hasGt = useGtValidation(1);
   const { createProposal, loading, error, success } = useCreateProposal();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -21,8 +23,20 @@ const ProposalCreator: React.FC = () => {
     }
   };
 
+  if (!hasGt) {
+    return (
+      <div className="text-gray-500">
+        Governance token balance insufficient to create proposals.
+      </div>
+    );
+  }
+
   if (!isValidated) {
-    return <div className="text-gray-500">AI assistant validation required to create proposals.</div>;
+    return (
+      <div className="text-gray-500">
+        AI assistant validation required to create proposals.
+      </div>
+    );
   }
 
   return (

--- a/src/components/law/VotePanel.tsx
+++ b/src/components/law/VotePanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import useVote from '../../hooks/useVote';
+import useGtValidation from '../../hooks/useGtValidation';
 
 interface VotePanelProps {
   proposalId: number;
@@ -7,10 +8,19 @@ interface VotePanelProps {
 }
 
 const VotePanel: React.FC<VotePanelProps> = ({ proposalId, userAddress }) => {
+  const hasGt = useGtValidation(1);
   const { voteYes, voteNo, abstain, loading, error, lastVote } = useVote(
     proposalId,
     userAddress,
   );
+
+  if (!hasGt) {
+    return (
+      <div className="p-4 border rounded text-gray-500">
+        Governance tokens are required to vote on proposals.
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 border rounded">

--- a/src/components/tasks/TaskBrowser.tsx
+++ b/src/components/tasks/TaskBrowser.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchTaskMetrics, setCurrentTask } from '../../store/taskSlice';
 import taskService from '../../services/taskService';
 import usePoOFlow from '../../hooks/usePoOFlow';
+import useGtValidation from '../../hooks/useGtValidation';
 import TaskMetricsCard from './TaskMetricsCard';
 
 interface Task {
@@ -16,6 +17,7 @@ interface TaskBrowserProps {
 }
 
 const TaskBrowser: React.FC<TaskBrowserProps> = ({ userAddress }) => {
+  const hasGt = useGtValidation(1);
   const dispatch = useDispatch();
   const tasks: Task[] = useSelector((state: any) => state.task.tasks);
   const metrics = useSelector((state: any) => state.task.metrics);
@@ -24,14 +26,16 @@ const TaskBrowser: React.FC<TaskBrowserProps> = ({ userAddress }) => {
   const { rewardAfterTask, loading: rewarding } = usePoOFlow(userAddress);
 
   useEffect(() => {
+    if (!hasGt) return;
     tasks.forEach((task) => {
       if (!metrics[task.id]) {
         dispatch(fetchTaskMetrics(task.id));
       }
     });
-  }, [tasks, metrics, dispatch]);
+  }, [tasks, metrics, dispatch, hasGt]);
 
   useEffect(() => {
+    if (!hasGt) return;
     // Example placeholder to show how a service could fetch tasks
     // Real implementation would call an API or contract here
     if (!tasks || tasks.length === 0) {
@@ -43,7 +47,7 @@ const TaskBrowser: React.FC<TaskBrowserProps> = ({ userAddress }) => {
         }
       })();
     }
-  }, [tasks]);
+  }, [tasks, hasGt]);
 
   const filteredTasks = tasks.filter((task) => {
     if (filter === 'completed') return completed.has(task.id);
@@ -68,6 +72,14 @@ const TaskBrowser: React.FC<TaskBrowserProps> = ({ userAddress }) => {
       console.error('Reward failed', err);
     }
   };
+
+  if (!hasGt) {
+    return (
+      <div className="p-4 text-gray-500">
+        Governance token balance required to access tasks.
+      </div>
+    );
+  }
 
   return (
     <div className="p-4">

--- a/src/hooks/useGtValidation.ts
+++ b/src/hooks/useGtValidation.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { ethers } from 'ethers';
+import useMpns from './useMpns';
+import { getProvider } from '../services/provider';
+
+/**
+ * Hook to validate that the connected wallet holds a minimum amount of
+ * governance tokens. The governance token contract address is resolved via
+ * MpNS using the name `houseOfCode.token.governance.mpns`.
+ *
+ * @param minGtBalance Minimum governance token balance required
+ * @returns boolean indicating whether the wallet satisfies the requirement
+ */
+export const useGtValidation = (minGtBalance: number | bigint = 1) => {
+  const address = useSelector((state: any) => state.wallet?.address);
+  const { result } = useMpns('houseOfCode.token.governance.mpns');
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    const checkBalance = async () => {
+      if (!address || result.type !== 'contract') {
+        setAllowed(false);
+        return;
+      }
+      try {
+        const provider = getProvider();
+        const contract = new ethers.Contract(
+          result.value,
+          ['function balanceOf(address owner) view returns (uint256)'],
+          provider,
+        );
+        const balance: ethers.BigNumber = await contract.balanceOf(address);
+        const required = ethers.BigNumber.from(minGtBalance);
+        setAllowed(balance.gte(required));
+      } catch (err) {
+        console.error('GT validation failed', err);
+        setAllowed(false);
+      }
+    };
+    checkBalance();
+  }, [address, result, minGtBalance]);
+
+  return allowed;
+};
+
+export default useGtValidation;


### PR DESCRIPTION
## Summary
- add `useGtValidation` hook to resolve governance token and check `balanceOf`
- gate proposal and task components behind governance token minimums

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68942fdae74c832a976ef43835b4b709