### PR TITLE
feat: add GPT recommendations hook

### DIFF
--- a/src/hooks/useGptRecommendation.ts
+++ b/src/hooks/useGptRecommendation.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import useMpns, { MpnsResolution } from './useMpns';
+import aiService from '../services/aiService';
+
+interface RootState {
+  gt: {
+    balance: number;
+  };
+}
+
+const fetchMpnsContent = async (res: MpnsResolution): Promise<any> => {
+  if (res.type === 'ipfs' && res.value) {
+    let url = res.value;
+    if (url.startsWith('ipfs://')) {
+      url = `https://ipfs.io/ipfs/${url.slice(7)}`;
+    }
+    try {
+      const resp = await fetch(url);
+      const text = await resp.text();
+      try {
+        return JSON.parse(text);
+      } catch {
+        return text;
+      }
+    } catch (err) {
+      console.error('Failed to fetch MpNS content', err);
+      return null;
+    }
+  }
+  return res.value;
+};
+
+const useGptRecommendation = (factionRulesName: string, userLevelName: string) => {
+  const { result: rulesResult } = useMpns(factionRulesName);
+  const { result: levelResult } = useMpns(userLevelName);
+  const balance = useSelector((state: RootState) => state.gt.balance);
+
+  const [suggestions, setSuggestions] = useState<any[]>([]);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+
+  useEffect(() => {
+    const run = async () => {
+      if (rulesResult.type === 'empty' || levelResult.type === 'empty') {
+        return;
+      }
+      setStatus('loading');
+      try {
+        const rules = await fetchMpnsContent(rulesResult);
+        const level = await fetchMpnsContent(levelResult);
+        const payload = { rules, level, balance };
+        const resp = await aiService.recommendProposals(payload);
+        setSuggestions(resp.proposals || []);
+        setStatus('ready');
+      } catch (err) {
+        console.error('Failed to get GPT recommendation', err);
+        setStatus('error');
+      }
+    };
+    run();
+  }, [rulesResult, levelResult, balance]);
+
+  return { suggestions, status };
+};
+
+export default useGptRecommendation;

--- a/src/pages/HouseOfCode/tasks.tsx
+++ b/src/pages/HouseOfCode/tasks.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import useMpns from '../../hooks/useMpns';
+import useGptRecommendation from '../../hooks/useGptRecommendation';
 
 interface Task {
   title?: string;
@@ -9,6 +10,10 @@ interface Task {
 const HouseOfCodeTasks: React.FC = () => {
   const { result } = useMpns('houseOfCode.tasks.level1.mpns');
   const [tasks, setTasks] = useState<Task[]>([]);
+  const { suggestions, status: suggestionStatus } = useGptRecommendation(
+    'houseOfCode.rules.mpns',
+    'user.level.mpns',
+  );
 
   useEffect(() => {
     const load = async () => {
@@ -34,17 +39,34 @@ const HouseOfCodeTasks: React.FC = () => {
   }, [result]);
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">House of Code Tasks</h1>
-      {tasks.length === 0 ? (
-        <div>No tasks found.</div>
-      ) : (
-        <ul className="list-disc pl-5 space-y-2">
-          {tasks.map((task, idx) => (
-            <li key={idx}>{task.title || `Task ${idx + 1}`}</li>
-          ))}
-        </ul>
-      )}
+    <div className="flex p-4">
+      <div className="flex-1 pr-4">
+        <h1 className="text-2xl font-bold mb-4">House of Code Tasks</h1>
+        {tasks.length === 0 ? (
+          <div>No tasks found.</div>
+        ) : (
+          <ul className="list-disc pl-5 space-y-2">
+            {tasks.map((task, idx) => (
+              <li key={idx}>{task.title || `Task ${idx + 1}`}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <aside className="w-64 border-l pl-4">
+        <h2 className="text-xl font-bold mb-2">AI Suggestions</h2>
+        {suggestionStatus === 'loading' && <div>Loading suggestions...</div>}
+        {suggestionStatus === 'error' && <div>Failed to load suggestions.</div>}
+        {suggestionStatus === 'ready' && suggestions.length === 0 && (
+          <div>No suggestions available.</div>
+        )}
+        {suggestions.length > 0 && (
+          <ul className="list-disc pl-5 space-y-2">
+            {suggestions.map((s, i) => (
+              <li key={i}>{s.title || JSON.stringify(s)}</li>
+            ))}
+          </ul>
+        )}
+      </aside>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `useGptRecommendation` hook that fetches faction rules and user levels via MpNS and queries the AI service for recommendations
- surface AI suggestions in House of Code tasks page sidebar

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6894322d51a0832ab431045125e2d696