### PR TITLE
feat: add charter metadata hook and faction defaults

### DIFF
--- a/src/components/factions/GenesisBlockDeployer.tsx
+++ b/src/components/factions/GenesisBlockDeployer.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import useFactionDeploy from '../../hooks/useFactionDeploy';
 import { addGenesisBlockFactoryEvent } from '../../store/eventSlices';
+import useCharterMetadata from '../../hooks/useCharterMetadata';
 
 interface GenesisBlockDeployerProps {
   account: string;
@@ -11,7 +12,16 @@ const GenesisBlockDeployer: React.FC<GenesisBlockDeployerProps> = ({ account }) 
   const dispatch = useDispatch();
   const { deployFaction, loading, error, factionAddress } = useFactionDeploy(account);
   const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
   const [txHash, setTxHash] = useState<string | null>(null);
+
+  const { metadata, immutableGenesis, agentHandles } = useCharterMetadata(name);
+
+  useEffect(() => {
+    if (metadata?.description) {
+      setDescription(metadata.description);
+    }
+  }, [metadata]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,6 +52,13 @@ const GenesisBlockDeployer: React.FC<GenesisBlockDeployerProps> = ({ account }) 
           className="border p-2 w-full"
           required
         />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="border p-2 w-full"
+          rows={4}
+        />
         <button
           type="submit"
           disabled={loading}
@@ -50,6 +67,18 @@ const GenesisBlockDeployer: React.FC<GenesisBlockDeployerProps> = ({ account }) 
           {loading ? 'Deploying...' : 'Deploy'}
         </button>
       </form>
+      {immutableGenesis !== null && (
+        <div className="mt-2">
+          <span className="font-semibold">Immutable Genesis:</span>{' '}
+          {immutableGenesis ? 'Yes' : 'No'}
+        </div>
+      )}
+      {agentHandles.length > 0 && (
+        <div className="mt-2">
+          <span className="font-semibold">Agent Handles:</span>{' '}
+          {agentHandles.join(', ')}
+        </div>
+      )}
       {txHash && (
         <div className="mt-4">
           <span className="font-semibold">Transaction Hash:</span> {txHash}

--- a/src/hooks/useCharterMetadata.ts
+++ b/src/hooks/useCharterMetadata.ts
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react';
+import useContract from './useContract';
+
+interface CharterMetadata {
+  [key: string]: any;
+}
+
+export const useCharterMetadata = (factionName?: string) => {
+  const [metadata, setMetadata] = useState<CharterMetadata | null>(null);
+  const [immutableGenesis, setImmutableGenesis] = useState<boolean | null>(null);
+  const [agentHandles, setAgentHandles] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const getRegistry = useContract('FactionCharterRegistry');
+
+  useEffect(() => {
+    const fetchMetadata = async () => {
+      if (!factionName) {
+        setMetadata(null);
+        setImmutableGenesis(null);
+        setAgentHandles([]);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const registry = await getRegistry();
+        const charter = await registry.getCharterByName(factionName);
+        if (charter?.ipfsHash) {
+          setImmutableGenesis(charter.immutableGenesis);
+          let url: string = charter.ipfsHash;
+          if (url.startsWith('ipfs://')) {
+            url = `https://ipfs.io/ipfs/${url.slice(7)}`;
+          } else if (!url.startsWith('http')) {
+            url = `https://ipfs.io/ipfs/${url}`;
+          }
+          const res = await fetch(url);
+          const data = await res.json();
+          setMetadata(data);
+          const agents = Array.isArray(data?.agents)
+            ? data.agents.map((a: any) =>
+                typeof a === 'string' ? a : a.handle || a.name || '',
+              )
+            : Array.isArray(data?.agentHandles)
+            ? data.agentHandles
+            : [];
+          setAgentHandles(agents.filter(Boolean));
+        } else {
+          setMetadata(null);
+          setImmutableGenesis(null);
+          setAgentHandles([]);
+        }
+      } catch (err: any) {
+        setError(err);
+        setMetadata(null);
+        setImmutableGenesis(null);
+        setAgentHandles([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMetadata();
+  }, [factionName, getRegistry]);
+
+  return { metadata, immutableGenesis, agentHandles, loading, error };
+};
+
+export default useCharterMetadata;
+


### PR DESCRIPTION
## Summary
- add hook to fetch faction charter data from chain and IPFS
- populate faction deployer defaults using charter metadata
- show immutable genesis flag and agent handles for transparency

## Testing
- `CI=true npm test -- --watch=false --passWithNoTests`
- `npm run build` *(fails: Module not found: Can't resolve 'H:\\Hardhat-Folder\\Project-test\\ai-powered-metaverse-pltf\\public\\images\\tron-grid-background.webp')*

------
https://chatgpt.com/codex/tasks/task_e_6894968bf85c832a947c3ad3d5f262fe