### PR TITLE
Add Architects Guild genesis placeholders

### DIFF
--- a/agents/architects-guild/AGENT.architects-guild.charter.mpns
+++ b/agents/architects-guild/AGENT.architects-guild.charter.mpns
@@ -1,0 +1,1 @@
+Genesis placeholder for the Architects Guild charter.

--- a/agents/architects-guild/AGENT.chartermentor.gpt.md
+++ b/agents/architects-guild/AGENT.chartermentor.gpt.md
@@ -1,0 +1,1 @@
+Placeholder for Charter Mentor document.

--- a/agents/architects-guild/AGENT.faction-template.content-creator.mpns
+++ b/agents/architects-guild/AGENT.faction-template.content-creator.mpns
@@ -1,0 +1,1 @@
+Placeholder for Content Creator faction template.

--- a/agents/architects-guild/AGENT.faction-template.labelDAO.mpns
+++ b/agents/architects-guild/AGENT.faction-template.labelDAO.mpns
@@ -1,0 +1,1 @@
+Placeholder for LabelDAO faction template.

--- a/agents/architects-guild/AGENT.token-audit.gpt.md
+++ b/agents/architects-guild/AGENT.token-audit.gpt.md
@@ -1,0 +1,1 @@
+Placeholder for Token Audit document.

--- a/agents/architects-guild/README.md
+++ b/agents/architects-guild/README.md
@@ -1,0 +1,4 @@
+# Architects Guild Genesis Files
+
+This directory contains immutable genesis files for the Architects Guild.
+These records are governed by the Genesis Faction and must not be modified.

--- a/agents/architects-guild/agents.json
+++ b/agents/architects-guild/agents.json
@@ -1,0 +1,37 @@
+[
+  {
+    "handle": "architects-guild-charter",
+    "description": "Genesis charter for the Architects Guild.",
+    "fileType": "mpns",
+    "ipfsHash": "QmArchitectsGuildCharter",
+    "version": "1.0.0"
+  },
+  {
+    "handle": "chartermentor",
+    "description": "Mentor charter for the Genesis program.",
+    "fileType": "gpt.md",
+    "ipfsHash": "QmCharterMentor",
+    "version": "1.0.0"
+  },
+  {
+    "handle": "token-audit",
+    "description": "Initial token audit.",
+    "fileType": "gpt.md",
+    "ipfsHash": "QmTokenAudit",
+    "version": "1.0.0"
+  },
+  {
+    "handle": "faction-template-content-creator",
+    "description": "Template for content creator faction.",
+    "fileType": "mpns",
+    "ipfsHash": "QmFactionTemplateContentCreator",
+    "version": "1.0.0"
+  },
+  {
+    "handle": "faction-template-labelDAO",
+    "description": "Template for labelDAO faction.",
+    "fileType": "mpns",
+    "ipfsHash": "QmFactionTemplateLabelDAO",
+    "version": "1.0.0"
+  }
+]


### PR DESCRIPTION
## Summary
- add Architects Guild genesis files and metadata registry
- document governance of genesis files by the Genesis Faction

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68952fbc90ec832abce17085b886336c