### PR TITLE
Add genesis flag and governance protections to MpNSRegistry

### DIFF
--- a/contracts/test/MpNSRegistry.test.ts
+++ b/contracts/test/MpNSRegistry.test.ts
@@ -4,14 +4,15 @@ import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 
 describe('MpNSRegistry', function () {
   async function deployRegistry() {
-    const [deployer, registrar, user] = await ethers.getSigners();
+    const [deployer, registrar, user, other, genesisGov] = await ethers.getSigners();
     const Registry = await ethers.getContractFactory('MpNSRegistry');
     const registry = await upgrades.deployProxy(Registry, { initializer: 'initialize' });
     await registry.waitForDeployment();
 
     await registry.grantRole(await registry.REGISTRAR_ROLE(), registrar.address);
+    await registry.grantRole(await registry.GENESIS_GOVERNANCE_ROLE(), genesisGov.address);
 
-    return { registry, deployer, registrar, user };
+    return { registry, deployer, registrar, user, other, genesisGov };
   }
 
   it('allows registrar to register and update names', async function () {
@@ -29,6 +30,7 @@ describe('MpNSRegistry', function () {
     ).to.emit(registry, 'URIUpdated').withArgs('alice', 'ipfs://old', 'ipfs://new');
 
     expect(await registry.nameToUri('alice')).to.equal('ipfs://new');
+    expect(await registry.isGenesis('alice')).to.equal(false);
   });
 
   it('reverts register for non-registrars', async function () {
@@ -39,5 +41,32 @@ describe('MpNSRegistry', function () {
     )
       .to.be.revertedWithCustomError(registry, 'AccessControlUnauthorizedAccount')
       .withArgs(user.address, role);
+  });
+
+  it('marks genesis records and restricts mutations', async function () {
+    const { registry, registrar, user, other, genesisGov } = await deployRegistry();
+    const duration = 60 * 60 * 24; // 1 day
+
+    await registry.connect(registrar).registerGenesis('gen', user.address, duration, 'ipfs://gen');
+
+    expect(await registry.isGenesis('gen')).to.equal(true);
+
+    await expect(
+      registry.connect(user).updateURI('gen', 'ipfs://new')
+    ).to.be.revertedWith('Genesis governance only');
+
+    await expect(
+      registry.connect(user).transfer('gen', other.address)
+    ).to.be.revertedWith('Genesis governance only');
+
+    await expect(
+      registry.connect(genesisGov).updateURI('gen', 'ipfs://new')
+    ).to.emit(registry, 'URIUpdated').withArgs('gen', 'ipfs://gen', 'ipfs://new');
+
+    await expect(
+      registry.connect(genesisGov).transfer('gen', other.address)
+    ).to.emit(registry, 'NameTransferred').withArgs('gen', user.address, other.address);
+
+    expect(await registry.ownerOf('gen')).to.equal(other.address);
   });
 });


### PR DESCRIPTION
## Summary
- Add `isGenesis` to `NameRecord` and expose through `isGenesis` view
- Introduce `GENESIS_GOVERNANCE_ROLE` and `registerGenesis`
- Block updates and transfers of genesis records unless caller has governance role
- Expand tests for genesis registrations and restrictions

## Testing
- `npx hardhat test test/MpNSRegistry.test.ts` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6895385135d4832a9665bf4d4501b613