### PR TITLE
Seed genesis agents from JSON

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,3 +19,14 @@ Placeholder steps for contract verification.
 
 Placeholder for required environment variable configuration.
 
+## Genesis Agent Seeding
+
+The bootstrap process seeds the Architects Guild with genesis agent handles.
+Run the following during deployment:
+
+```
+npx hardhat run scripts/deploy-genesis-block.ts
+```
+
+This invokes `scripts/seed-architects-guild.ts`, which reads `agents/architects-guild/agents.json`, registers each handle via the registry's `registerGenesis` function, and freezes the names so `isGenesis` remains true.
+


### PR DESCRIPTION
## Summary
- load Architects Guild agent specs from JSON and register them as genesis names with ipfs URIs
- document bootstrap seeding of Architects Guild agents in deployment guide

## Testing
- `npx hardhat test` *(fails: HH502: Couldn't download compiler version list - Proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68953b0fd25c832ab36fe2ec32e87a71