### PR TITLE
feat: add agent service and viewer

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -146,3 +146,9 @@ This directory houses React components for the AI-Powered Metaverse Platform. Ea
 - **Smart-contract or AI:** none.
 - **Extension points:** wire to Redux or API sources and add pagination.
 
+## agents/AgentMarkdownViewer.tsx
+- **UI purpose:** Fetches an agent's metadata and displays its `AGENT.md` content.
+- **Redux slices:** none.
+- **Smart-contract or AI:** uses `useAgent` which leverages `agentService` and IPFS utilities.
+- **Extension points:** customize markdown rendering or styling.
+

--- a/src/components/agents/AgentMarkdownViewer.tsx
+++ b/src/components/agents/AgentMarkdownViewer.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import useAgent from '../../hooks/useAgent';
+import LoadingSpinner from '../shared/LoadingSpinner';
+
+interface Props {
+  handle: string;
+}
+
+const AgentMarkdownViewer: React.FC<Props> = ({ handle }) => {
+  const { agent, loading, error } = useAgent(handle);
+
+  if (loading) return <LoadingSpinner size="md" text="Loading agent..." />;
+  if (error) return <div>Error loading agent.</div>;
+  if (!agent) return <div>Agent not found.</div>;
+
+  return (
+    <pre style={{ whiteSpace: 'pre-wrap' }}>
+      {agent.content || 'No content available.'}
+    </pre>
+  );
+};
+
+export default AgentMarkdownViewer;

--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { getAgent, AgentMetadata } from '../services/agentService';
+
+export const useAgent = (handle?: string) => {
+  const [agent, setAgent] = useState<AgentMetadata | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchAgent = async () => {
+      if (!handle) {
+        setAgent(null);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getAgent(handle);
+        setAgent(data);
+      } catch (err: any) {
+        setError(err);
+        setAgent(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAgent();
+  }, [handle]);
+
+  return { agent, loading, error };
+};
+
+export default useAgent;

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -1,0 +1,31 @@
+import agents from '../../agents/architects-guild/agents.json';
+import ipfsService from './ipfsService';
+
+export interface AgentMetadata {
+  handle: string;
+  description?: string;
+  fileType?: string;
+  ipfsHash?: string;
+  version?: string;
+  content?: string;
+}
+
+const agentList: AgentMetadata[] = agents as AgentMetadata[];
+
+export const getAgent = async (handle: string): Promise<AgentMetadata | null> => {
+  const metadata = agentList.find((a) => a.handle === handle);
+  if (!metadata) return null;
+  let content: string | undefined;
+  if (metadata.ipfsHash) {
+    try {
+      content = await ipfsService.fetchFromIPFS(metadata.ipfsHash);
+    } catch (error) {
+      console.error('Error fetching AGENT.md from IPFS:', error);
+    }
+  }
+  return { ...metadata, content };
+};
+
+export default {
+  getAgent,
+};

--- a/src/services/ipfsService.js
+++ b/src/services/ipfsService.js
@@ -40,7 +40,19 @@ export const uploadAgentMd = async (fileOrString) => {
   }
 };
 
+export const fetchFromIPFS = async (hash) => {
+  try {
+    const url = `https://ipfs.io/ipfs/${hash}`;
+    const response = await axios.get(url, { responseType: 'text' });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching from IPFS:', error);
+    throw error;
+  }
+};
+
 export default {
   uploadDocument,
   uploadAgentMd,
+  fetchFromIPFS,
 };


### PR DESCRIPTION
## Summary
- add agentService to load local agents and pull AGENT.md from IPFS
- expose useAgent hook and AgentMarkdownViewer component for UI
- document AgentMarkdownViewer in components guide and extend IPFS utilities

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npx tsc --noEmit` *(fails: Cannot find module '../../hooks/useStakeGT', BigInt literals not available, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68953e81e9e4832aa3995c49c5316e50