### PR TITLE
refactor: add faction page template

### DIFF
--- a/src/components/FactionPageTemplate.js
+++ b/src/components/FactionPageTemplate.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import '../styles/FactionPage.css';
+
+const FactionPageTemplate = ({ title, description, charter, mission, focus, courseLink }) => {
+  return (
+    <div className="faction-page">
+      <h1>{title}</h1>
+      <p>{description}</p>
+
+      <div className="documents-section">
+        <h2>Documents</h2>
+        <ul>
+          <li><a href="#charter">Charter</a></li>
+          <li><a href="#mission">Mission</a></li>
+          <li><a href="#focus">Focus</a></li>
+        </ul>
+      </div>
+
+      <section id="charter">
+        <h2>Charter</h2>
+        {charter}
+      </section>
+
+      <section id="mission">
+        <h2>Mission</h2>
+        {mission}
+      </section>
+
+      <section id="focus">
+        <h2>Focus</h2>
+        {focus}
+      </section>
+
+      {courseLink && (
+        <Link to={courseLink} className="course-link">
+          View Course
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default FactionPageTemplate;

--- a/src/pages/AIArchitect.js
+++ b/src/pages/AIArchitect.js
@@ -1,54 +1,42 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import '../styles/FactionPage.css';
+import FactionPageTemplate from '../components/FactionPageTemplate';
 
 const AIArchitect = () => {
-    return (
-      <div className="faction-page">
-        <h1>AI Architect</h1>
-        <p>Designing and implementing advanced artificial intelligence systems and promoting AI ethics.</p>
-        
-        <div className="documents-section">
-          <h2>Documents</h2>
-          <ul>
-            <li><a href="#charter">Charter</a></li>
-            <li><a href="#mission">Mission</a></li>
-            <li><a href="#focus">Focus</a></li>
-            {/* Add more links to documents */}
-          </ul>
-        </div>
-  
-        <section id="charter">
-          <h2>Charter</h2>
+  return (
+    <FactionPageTemplate
+      title="AI Architect"
+      description="Designing and implementing advanced artificial intelligence systems and promoting AI ethics."
+      charter={(
+        <>
           <p>
-            The AI Architect Charter establishes the foundation for our operations, governance, and strategic objectives. 
-            Our primary aim is to foster innovation in artificial intelligence through collaborative efforts, education, and real-world applications. 
-            We uphold the principles of transparency, ethics, and responsibility as we navigate the evolving landscape of AI and machine learning.
+            The AI Architect Charter establishes the foundation for our operations, governance, and strategic objectives. Our
+            primary aim is to foster innovation in artificial intelligence through collaborative efforts, education, and real-world
+            applications. We uphold the principles of transparency, ethics, and responsibility as we navigate the evolving landscape
+            of AI and machine learning.
           </p>
           <p>
-            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular meetings, 
-            voting on proposals, and community engagement are key components of our governance framework.
+            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular
+            meetings, voting on proposals, and community engagement are key components of our governance framework.
           </p>
-        </section>
-  
-        <section id="mission">
-          <h2>Mission</h2>
+        </>
+      )}
+      mission={(
+        <>
           <p>
-            Our mission is to advance the development and application of artificial intelligence by providing a platform for education, innovation, 
-            and collaboration. We aim to create an ecosystem where developers, researchers, and enthusiasts can come together to share knowledge, 
-            develop new technologies, and drive the adoption of AI solutions across various industries.
+            Our mission is to advance the development and application of artificial intelligence by providing a platform for
+            education, innovation, and collaboration. We aim to create an ecosystem where developers, researchers, and enthusiasts
+            can come together to share knowledge, develop new technologies, and drive the adoption of AI solutions across various
+            industries.
           </p>
           <p>
-            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the AI revolution, 
-            contributing to the broader community and influencing the future of intelligent technologies.
+            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the AI
+            revolution, contributing to the broader community and influencing the future of intelligent technologies.
           </p>
-        </section>
-  
-        <section id="focus">
-          <h2>Focus</h2>
-          <p>
-            Our focus areas include:
-          </p>
+        </>
+      )}
+      focus={(
+        <>
+          <p>Our focus areas include:</p>
           <ul>
             <li>Developing advanced machine learning algorithms</li>
             <li>Exploring ethical implications and AI governance</li>
@@ -57,14 +45,14 @@ const AIArchitect = () => {
             <li>Promoting AI education and community engagement</li>
           </ul>
           <p>
-            Through these focus areas, we aim to address current challenges in the AI space and drive forward the adoption of innovative solutions 
-            that can transform industries and create new opportunities.
+            Through these focus areas, we aim to address current challenges in the AI space and drive forward the adoption of
+            innovative solutions that can transform industries and create new opportunities.
           </p>
-        </section>
-  
-        <Link to="/ai-architect/course" className="course-link">View Course</Link>
-      </div>
-    );
-  };
-  
-  export default AIArchitect;
+        </>
+      )}
+      courseLink="/ai-architect/course"
+    />
+  );
+};
+
+export default AIArchitect;

--- a/src/pages/BlockchainBattalion.js
+++ b/src/pages/BlockchainBattalion.js
@@ -1,54 +1,41 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import '../styles/FactionPage.css';
+import FactionPageTemplate from '../components/FactionPageTemplate';
 
 const BlockchainBattalion = () => {
-    return (
-      <div className="faction-page">
-        <h1>Blockchain Battalion</h1>
-        <p>Exploring and developing the next generation of blockchain technologies and smart contracts.</p>
-        
-        <div className="documents-section">
-          <h2>Documents</h2>
-          <ul>
-            <li><a href="#charter">Charter</a></li>
-            <li><a href="#mission">Mission</a></li>
-            <li><a href="#focus">Focus</a></li>
-            {/* Add more links to documents */}
-          </ul>
-        </div>
-  
-        <section id="charter">
-          <h2>Charter</h2>
+  return (
+    <FactionPageTemplate
+      title="Blockchain Battalion"
+      description="Exploring and developing the next generation of blockchain technologies and smart contracts."
+      charter={(
+        <>
           <p>
-            The Blockchain Battalion Charter establishes the foundation for our operations, governance, and strategic objectives. 
-            Our primary aim is to foster innovation in blockchain technology through collaborative efforts, education, and real-world applications. 
-            We uphold the principles of decentralization, transparency, and security as we navigate the evolving landscape of blockchain and digital assets.
+            The Blockchain Battalion Charter establishes the foundation for our operations, governance, and strategic objectives.
+            Our primary aim is to foster innovation in blockchain technology through collaborative efforts, education, and real-world
+            applications. We uphold the principles of decentralization, transparency, and security as we navigate the evolving landscape
+            of blockchain and digital assets.
           </p>
           <p>
-            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular meetings, 
-            voting on proposals, and community engagement are key components of our governance framework.
+            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular
+            meetings, voting on proposals, and community engagement are key components of our governance framework.
           </p>
-        </section>
-  
-        <section id="mission">
-          <h2>Mission</h2>
+        </>
+      )}
+      mission={(
+        <>
           <p>
-            Our mission is to advance the development and application of blockchain technology by providing a platform for education, innovation, 
-            and collaboration. We aim to create an ecosystem where developers, researchers, and enthusiasts can come together to share knowledge, 
-            develop new technologies, and drive the adoption of blockchain solutions across various industries.
+            Our mission is to advance the development and application of blockchain technology by providing a platform for education,
+            innovation, and collaboration. We aim to create an ecosystem where developers, researchers, and enthusiasts can come together
+            to share knowledge, develop new technologies, and drive the adoption of blockchain solutions across various industries.
           </p>
           <p>
-            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the blockchain revolution, 
-            contributing to the broader community and influencing the future of decentralized technologies.
+            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the blockchain
+            revolution, contributing to the broader community and influencing the future of decentralized technologies.
           </p>
-        </section>
-  
-        <section id="focus">
-          <h2>Focus</h2>
-          <p>
-            Our focus areas include:
-          </p>
+        </>
+      )}
+      focus={(
+        <>
+          <p>Our focus areas include:</p>
           <ul>
             <li>Developing secure and scalable blockchain protocols</li>
             <li>Advancing smart contract technology and programming</li>
@@ -58,14 +45,14 @@ const BlockchainBattalion = () => {
             <li>Promoting blockchain education and community engagement</li>
           </ul>
           <p>
-            Through these focus areas, we aim to address current challenges in the blockchain space and drive forward the adoption of innovative solutions 
-            that can transform industries and create new opportunities.
+            Through these focus areas, we aim to address current challenges in the blockchain space and drive forward the adoption of
+            innovative solutions that can transform industries and create new opportunities.
           </p>
-        </section>
-  
-        <Link to="/blockchain-battalion/course" className="course-link">View Course</Link>
-      </div>
-    );
-  };
-  
-  export default BlockchainBattalion;
+        </>
+      )}
+      courseLink="/blockchain-battalion/course"
+    />
+  );
+};
+
+export default BlockchainBattalion;

--- a/src/pages/IoTInnovator.js
+++ b/src/pages/IoTInnovator.js
@@ -1,54 +1,41 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import '../styles/FactionPage.css';
+import FactionPageTemplate from '../components/FactionPageTemplate';
 
 const IoTInnovator = () => {
-    return (
-      <div className="faction-page">
-        <h1>IoT Innovator</h1>
-        <p>Pioneering innovations in Internet of Things (IoT) systems and enhancing IoT security.</p>
-        
-        <div className="documents-section">
-          <h2>Documents</h2>
-          <ul>
-            <li><a href="#charter">Charter</a></li>
-            <li><a href="#mission">Mission</a></li>
-            <li><a href="#focus">Focus</a></li>
-            {/* Add more links to documents */}
-          </ul>
-        </div>
-  
-        <section id="charter">
-          <h2>Charter</h2>
+  return (
+    <FactionPageTemplate
+      title="IoT Innovator"
+      description="Pioneering innovations in Internet of Things (IoT) systems and enhancing IoT security."
+      charter={(
+        <>
           <p>
-            The IoT Innovator Charter establishes the foundation for our operations, governance, and strategic objectives. 
-            Our primary aim is to foster innovation in Internet of Things (IoT) technology through collaborative efforts, education, and real-world applications. 
-            We uphold the principles of connectivity, security, and innovation as we navigate the evolving landscape of IoT and smart systems.
+            The IoT Innovator Charter establishes the foundation for our operations, governance, and strategic objectives. Our primary
+            aim is to foster innovation in Internet of Things (IoT) technology through collaborative efforts, education, and real-world
+            applications. We uphold the principles of connectivity, security, and innovation as we navigate the evolving landscape of IoT
+            and smart systems.
           </p>
           <p>
-            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular meetings, 
+            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular meetings,
             voting on proposals, and community engagement are key components of our governance framework.
           </p>
-        </section>
-  
-        <section id="mission">
-          <h2>Mission</h2>
+        </>
+      )}
+      mission={(
+        <>
           <p>
-            Our mission is to advance the development and application of Internet of Things technology by providing a platform for education, innovation, 
-            and collaboration. We aim to create an ecosystem where developers, researchers, and enthusiasts can come together to share knowledge, 
-            develop new technologies, and drive the adoption of IoT solutions across various industries.
+            Our mission is to advance the development and application of Internet of Things technology by providing a platform for education,
+            innovation, and collaboration. We aim to create an ecosystem where developers, researchers, and enthusiasts can come together to
+            share knowledge, develop new technologies, and drive the adoption of IoT solutions across various industries.
           </p>
           <p>
-            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the IoT revolution, 
+            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the IoT revolution,
             contributing to the broader community and influencing the future of connected devices and smart systems.
           </p>
-        </section>
-  
-        <section id="focus">
-          <h2>Focus</h2>
-          <p>
-            Our focus areas include:
-          </p>
+        </>
+      )}
+      focus={(
+        <>
+          <p>Our focus areas include:</p>
           <ul>
             <li>Developing secure and scalable IoT infrastructures</li>
             <li>Advancing IoT device integration and interoperability</li>
@@ -57,14 +44,14 @@ const IoTInnovator = () => {
             <li>Promoting IoT education and community engagement</li>
           </ul>
           <p>
-            Through these focus areas, we aim to address current challenges in the IoT space and drive forward the adoption of innovative solutions 
-            that can transform industries and create new opportunities.
+            Through these focus areas, we aim to address current challenges in the IoT space and drive forward the adoption of innovative
+            solutions that can transform industries and create new opportunities.
           </p>
-        </section>
-  
-        <Link to="/iot-innovator/course" className="course-link">View Course</Link>
-      </div>
-    );
-  };
-  
-  export default IoTInnovator;
+        </>
+      )}
+      courseLink="/iot-innovator/course"
+    />
+  );
+};
+
+export default IoTInnovator;

--- a/src/pages/QuantumQuorist.js
+++ b/src/pages/QuantumQuorist.js
@@ -1,54 +1,42 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import '../styles/FactionPage.css';
+import FactionPageTemplate from '../components/FactionPageTemplate';
 
 const QuantumQuorist = () => {
-    return (
-      <div className="faction-page">
-        <h1>Quantum Quorist</h1>
-        <p>Advancing the understanding and application of quantum mechanics and computing.</p>
-        
-        <div className="documents-section">
-          <h2>Documents</h2>
-          <ul>
-            <li><a href="#charter">Charter</a></li>
-            <li><a href="#mission">Mission</a></li>
-            <li><a href="#focus">Focus</a></li>
-            {/* Add more links to documents */}
-          </ul>
-        </div>
-  
-        <section id="charter">
-          <h2>Charter</h2>
+  return (
+    <FactionPageTemplate
+      title="Quantum Quorist"
+      description="Advancing the understanding and application of quantum mechanics and computing."
+      charter={(
+        <>
           <p>
-            The Quantum Quorist Charter establishes the foundation for our operations, governance, and strategic objectives. 
-            Our primary aim is to foster innovation in quantum mechanics and computing through collaborative efforts, education, and real-world applications. 
-            We uphold the principles of scientific rigor, transparency, and ethical considerations as we navigate the evolving landscape of quantum technologies.
+            The Quantum Quorist Charter establishes the foundation for our operations, governance, and strategic objectives. Our primary
+            aim is to foster innovation in quantum mechanics and computing through collaborative efforts, education, and real-world
+            applications. We uphold the principles of scientific rigor, transparency, and ethical considerations as we navigate the
+            evolving landscape of quantum technologies.
           </p>
           <p>
-            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular meetings, 
+            The governance structure includes a decentralized decision-making process, ensuring all members have a voice. Regular meetings,
             voting on proposals, and community engagement are key components of our governance framework.
           </p>
-        </section>
-  
-        <section id="mission">
-          <h2>Mission</h2>
+        </>
+      )}
+      mission={(
+        <>
           <p>
-            Our mission is to advance the development and application of quantum mechanics and computing by providing a platform for education, innovation, 
-            and collaboration. We aim to create an ecosystem where scientists, researchers, and enthusiasts can come together to share knowledge, 
-            develop new technologies, and drive the adoption of quantum solutions across various industries.
+            Our mission is to advance the development and application of quantum mechanics and computing by providing a platform for
+            education, innovation, and collaboration. We aim to create an ecosystem where scientists, researchers, and enthusiasts can
+            come together to share knowledge, develop new technologies, and drive the adoption of quantum solutions across various
+            industries.
           </p>
           <p>
-            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the quantum revolution, 
+            By focusing on cutting-edge research and practical implementations, we strive to be at the forefront of the quantum revolution,
             contributing to the broader community and influencing the future of quantum technologies.
           </p>
-        </section>
-  
-        <section id="focus">
-          <h2>Focus</h2>
-          <p>
-            Our focus areas include:
-          </p>
+        </>
+      )}
+      focus={(
+        <>
+          <p>Our focus areas include:</p>
           <ul>
             <li>Advancing quantum computing algorithms and architectures</li>
             <li>Exploring quantum cryptography and secure communications</li>
@@ -57,14 +45,14 @@ const QuantumQuorist = () => {
             <li>Promoting quantum education and community engagement</li>
           </ul>
           <p>
-            Through these focus areas, we aim to address current challenges in the quantum space and drive forward the adoption of innovative solutions 
-            that can transform industries and create new opportunities.
+            Through these focus areas, we aim to address current challenges in the quantum space and drive forward the adoption of
+            innovative solutions that can transform industries and create new opportunities.
           </p>
-        </section>
-  
-        <Link to="/quantum-quorist/course" className="course-link">View Course</Link>
-      </div>
-    );
-  };
-  
-  export default QuantumQuorist;
+        </>
+      )}
+      courseLink="/quantum-quorist/course"
+    />
+  );
+};
+
+export default QuantumQuorist;


### PR DESCRIPTION
## Summary
- add reusable FactionPageTemplate component for shared faction layout
- refactor AIArchitect, BlockchainBattalion, IoTInnovator, and QuantumQuorist pages to use template

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build` *(fails: Module not found: Can't resolve 'H:\\Hardhat-Folder\\Project-test\\ai-powered-metaverse-pltf\\public\\images\\tron-grid-background.webp')*


------
https://chatgpt.com/codex/tasks/task_e_6895519ed7d0832a8367d649d693001c