### PR TITLE
refactor: add reusable course page template

### DIFF
--- a/src/components/CoursePageTemplate.js
+++ b/src/components/CoursePageTemplate.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import '../styles/CoursePage.css';
+
+const CoursePageTemplate = ({
+  title,
+  courseTitle,
+  overview,
+  objectives = [],
+  modules = [],
+  projects,
+  assessment,
+  resources,
+}) => {
+  return (
+    <div className="course-page">
+      <h1>{title}</h1>
+
+      {courseTitle && (
+        <section>
+          <h2>Course Title</h2>
+          <p>{courseTitle}</p>
+        </section>
+      )}
+
+      {overview && (
+        <section>
+          <h2>Course Overview</h2>
+          <p>{overview}</p>
+        </section>
+      )}
+
+      {objectives.length > 0 && (
+        <section>
+          <h2>Learning Objectives</h2>
+          <ul>
+            {objectives.map((obj, index) => (
+              <li key={index}>{obj}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {modules.length > 0 && (
+        <section>
+          <h2>Modules and Lessons</h2>
+          {modules.map((module, index) => (
+            <div className="module" key={index}>
+              <h3>{module.title}</h3>
+              <ul>
+                {module.lessons.map((lesson, lessonIndex) => (
+                  <li key={lessonIndex}>{lesson}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {projects && (
+        <section>
+          <h2>Hands-On Projects</h2>
+          <p>{projects}</p>
+        </section>
+      )}
+
+      {assessment && (
+        <section>
+          <h2>Assessment and Certification</h2>
+          <p>{assessment}</p>
+        </section>
+      )}
+
+      {resources && (
+        <section>
+          <h2>Additional Resources</h2>
+          <p>{resources}</p>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default CoursePageTemplate;

--- a/src/pages/AICourse.js
+++ b/src/pages/AICourse.js
@@ -1,88 +1,51 @@
 import React from 'react';
-import '../styles/CoursePage.css';
+import CoursePageTemplate from '../components/CoursePageTemplate';
 
-const AICourse = () => {
-  return (
-    <div className="course-page">
-      <h1>AI Architect: Comprehensive AI Course</h1>
-      
-      <section>
-        <h2>Course Title</h2>
-        <p>Comprehensive AI Course</p>
-      </section>
-
-      <section>
-        <h2>Course Overview</h2>
-        <p>
-          This course provides an in-depth understanding of artificial intelligence and its applications, focusing on both theoretical concepts and practical skills. 
-          Designed for developers and technology enthusiasts, the course requires basic programming knowledge and an interest in AI technologies.
-        </p>
-      </section>
-
-      <section>
-        <h2>Learning Objectives</h2>
-        <ul>
-          <li>Understand the fundamentals of artificial intelligence</li>
-          <li>Learn machine learning algorithms and techniques</li>
-          <li>Build intelligent systems and applications</li>
-          <li>Explore ethical considerations and AI governance</li>
-        </ul>
-      </section>
-
-      <section>
-        <h2>Modules and Lessons</h2>
-        <div className="module">
-          <h3>Module 1: Introduction to AI</h3>
-          <ul>
-            <li>Lesson 1: Overview of Artificial Intelligence</li>
-            <li>Lesson 2: History and Evolution of AI</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 2: Machine Learning</h3>
-          <ul>
-            <li>Lesson 1: Basics of Machine Learning</li>
-            <li>Lesson 2: Advanced Machine Learning Techniques</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 3: AI Systems Development</h3>
-          <ul>
-            <li>Lesson 1: Designing Intelligent Systems</li>
-            <li>Lesson 2: Implementing AI Solutions</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 4: Ethics and Governance</h3>
-          <ul>
-            <li>Lesson 1: Ethical Implications of AI</li>
-            <li>Lesson 2: AI Governance and Regulation</li>
-          </ul>
-        </div>
-      </section>
-
-      <section>
-        <h2>Hands-On Projects</h2>
-        <p>
-          Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your AI development skills.
-        </p>
-      </section>
-
-      <section>
-        <h2>Assessment and Certification</h2>
-        <p>
-          The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in artificial intelligence.
-        </p>
-      </section>
-
-      <section>
-        <h2>Additional Resources</h2>
-        <p>
-          Access a list of recommended readings, tools, and forums to further your knowledge and connect with other AI enthusiasts.
-        </p>
-      </section>
-    </div>
-  );
+const aiCourseData = {
+  title: 'AI Architect: Comprehensive AI Course',
+  courseTitle: 'Comprehensive AI Course',
+  overview: `This course provides an in-depth understanding of artificial intelligence and its applications, focusing on both theoretical concepts and practical skills. Designed for developers and technology enthusiasts, the course requires basic programming knowledge and an interest in AI technologies.`,
+  objectives: [
+    'Understand the fundamentals of artificial intelligence',
+    'Learn machine learning algorithms and techniques',
+    'Build intelligent systems and applications',
+    'Explore ethical considerations and AI governance',
+  ],
+  modules: [
+    {
+      title: 'Module 1: Introduction to AI',
+      lessons: [
+        'Lesson 1: Overview of Artificial Intelligence',
+        'Lesson 2: History and Evolution of AI',
+      ],
+    },
+    {
+      title: 'Module 2: Machine Learning',
+      lessons: [
+        'Lesson 1: Basics of Machine Learning',
+        'Lesson 2: Advanced Machine Learning Techniques',
+      ],
+    },
+    {
+      title: 'Module 3: AI Systems Development',
+      lessons: [
+        'Lesson 1: Designing Intelligent Systems',
+        'Lesson 2: Implementing AI Solutions',
+      ],
+    },
+    {
+      title: 'Module 4: Ethics and Governance',
+      lessons: [
+        'Lesson 1: Ethical Implications of AI',
+        'Lesson 2: AI Governance and Regulation',
+      ],
+    },
+  ],
+  projects: `Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your AI development skills.`,
+  assessment: `The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in artificial intelligence.`,
+  resources: `Access a list of recommended readings, tools, and forums to further your knowledge and connect with other AI enthusiasts.`,
 };
+
+const AICourse = () => <CoursePageTemplate {...aiCourseData} />;
 
 export default AICourse;

--- a/src/pages/BlockchainCourse.js
+++ b/src/pages/BlockchainCourse.js
@@ -1,88 +1,51 @@
 import React from 'react';
-import '../styles/CoursePage.css';
+import CoursePageTemplate from '../components/CoursePageTemplate';
 
-const BlockchainCourse = () => {
-  return (
-    <div className="course-page">
-      <h1>Blockchain Battalion: Comprehensive Blockchain Course</h1>
-      
-      <section>
-        <h2>Course Title</h2>
-        <p>Comprehensive Blockchain Course</p>
-      </section>
-
-      <section>
-        <h2>Course Overview</h2>
-        <p>
-          This course provides an in-depth understanding of blockchain technology and its applications, focusing on both theoretical concepts and practical skills. 
-          Designed for developers and technology enthusiasts, the course requires basic programming knowledge and an interest in blockchain technologies.
-        </p>
-      </section>
-
-      <section>
-        <h2>Learning Objectives</h2>
-        <ul>
-          <li>Understand the fundamentals of blockchain technology</li>
-          <li>Learn Solidity programming and smart contract development</li>
-          <li>Build decentralized applications (DApps)</li>
-          <li>Deploy and manage blockchain projects</li>
-        </ul>
-      </section>
-
-      <section>
-        <h2>Modules and Lessons</h2>
-        <div className="module">
-          <h3>Module 1: Introduction</h3>
-          <ul>
-            <li>Lesson 1: Overview of Blockchain Technology</li>
-            <li>Lesson 2: Ethereum and its Ecosystem</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 2: Solidity Programming</h3>
-          <ul>
-            <li>Lesson 1: Basics of Solidity</li>
-            <li>Lesson 2: Advanced Solidity Concepts</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 3: Smart Contracts Development</h3>
-          <ul>
-            <li>Lesson 1: Writing Smart Contracts</li>
-            <li>Lesson 2: Testing and Deployment</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 4: DApps Development</h3>
-          <ul>
-            <li>Lesson 1: Building Frontend for DApps</li>
-            <li>Lesson 2: Integrating with Smart Contracts</li>
-          </ul>
-        </div>
-      </section>
-
-      <section>
-        <h2>Hands-On Projects</h2>
-        <p>
-          Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your blockchain development skills.
-        </p>
-      </section>
-
-      <section>
-        <h2>Assessment and Certification</h2>
-        <p>
-          The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in blockchain technology.
-        </p>
-      </section>
-
-      <section>
-        <h2>Additional Resources</h2>
-        <p>
-          Access a list of recommended readings, tools, and forums to further your knowledge and connect with other blockchain enthusiasts.
-        </p>
-      </section>
-    </div>
-  );
+const blockchainCourseData = {
+  title: 'Blockchain Battalion: Comprehensive Blockchain Course',
+  courseTitle: 'Comprehensive Blockchain Course',
+  overview: `This course provides an in-depth understanding of blockchain technology and its applications, focusing on both theoretical concepts and practical skills. Designed for developers and technology enthusiasts, the course requires basic programming knowledge and an interest in blockchain technologies.`,
+  objectives: [
+    'Understand the fundamentals of blockchain technology',
+    'Learn Solidity programming and smart contract development',
+    'Build decentralized applications (DApps)',
+    'Deploy and manage blockchain projects',
+  ],
+  modules: [
+    {
+      title: 'Module 1: Introduction',
+      lessons: [
+        'Lesson 1: Overview of Blockchain Technology',
+        'Lesson 2: Ethereum and its Ecosystem',
+      ],
+    },
+    {
+      title: 'Module 2: Solidity Programming',
+      lessons: [
+        'Lesson 1: Basics of Solidity',
+        'Lesson 2: Advanced Solidity Concepts',
+      ],
+    },
+    {
+      title: 'Module 3: Smart Contracts Development',
+      lessons: [
+        'Lesson 1: Writing Smart Contracts',
+        'Lesson 2: Testing and Deployment',
+      ],
+    },
+    {
+      title: 'Module 4: DApps Development',
+      lessons: [
+        'Lesson 1: Building Frontend for DApps',
+        'Lesson 2: Integrating with Smart Contracts',
+      ],
+    },
+  ],
+  projects: `Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your blockchain development skills.`,
+  assessment: `The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in blockchain technology.`,
+  resources: `Access a list of recommended readings, tools, and forums to further your knowledge and connect with other blockchain enthusiasts.`,
 };
+
+const BlockchainCourse = () => <CoursePageTemplate {...blockchainCourseData} />;
 
 export default BlockchainCourse;

--- a/src/pages/IoTCourse.js
+++ b/src/pages/IoTCourse.js
@@ -1,88 +1,51 @@
 import React from 'react';
-import '../styles/CoursePage.css';
+import CoursePageTemplate from '../components/CoursePageTemplate';
 
-const IoTCourse = () => {
-  return (
-    <div className="course-page">
-      <h1>IoT Innovator: Comprehensive IoT Course</h1>
-      
-      <section>
-        <h2>Course Title</h2>
-        <p>Comprehensive IoT Course</p>
-      </section>
-
-      <section>
-        <h2>Course Overview</h2>
-        <p>
-          This course provides an in-depth understanding of Internet of Things (IoT) technology and its applications, focusing on both theoretical concepts and practical skills. 
-          Designed for developers and technology enthusiasts, the course requires basic programming knowledge and an interest in IoT technologies.
-        </p>
-      </section>
-
-      <section>
-        <h2>Learning Objectives</h2>
-        <ul>
-          <li>Understand the fundamentals of IoT technology</li>
-          <li>Learn IoT device integration and interoperability</li>
-          <li>Build smart applications and systems</li>
-          <li>Explore IoT security and privacy considerations</li>
-        </ul>
-      </section>
-
-      <section>
-        <h2>Modules and Lessons</h2>
-        <div className="module">
-          <h3>Module 1: Introduction to IoT</h3>
-          <ul>
-            <li>Lesson 1: Overview of Internet of Things</li>
-            <li>Lesson 2: History and Evolution of IoT</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 2: IoT Devices and Protocols</h3>
-          <ul>
-            <li>Lesson 1: Basics of IoT Devices</li>
-            <li>Lesson 2: IoT Communication Protocols</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 3: IoT Systems Development</h3>
-          <ul>
-            <li>Lesson 1: Designing IoT Systems</li>
-            <li>Lesson 2: Implementing IoT Solutions</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 4: IoT Security and Privacy</h3>
-          <ul>
-            <li>Lesson 1: Securing IoT Systems</li>
-            <li>Lesson 2: Privacy Considerations in IoT</li>
-          </ul>
-        </div>
-      </section>
-
-      <section>
-        <h2>Hands-On Projects</h2>
-        <p>
-          Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your IoT development skills.
-        </p>
-      </section>
-
-      <section>
-        <h2>Assessment and Certification</h2>
-        <p>
-          The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in Internet of Things technology.
-        </p>
-      </section>
-
-      <section>
-        <h2>Additional Resources</h2>
-        <p>
-          Access a list of recommended readings, tools, and forums to further your knowledge and connect with other IoT enthusiasts.
-        </p>
-      </section>
-    </div>
-  );
+const iotCourseData = {
+  title: 'IoT Innovator: Comprehensive IoT Course',
+  courseTitle: 'Comprehensive IoT Course',
+  overview: `This course provides an in-depth understanding of Internet of Things (IoT) technology and its applications, focusing on both theoretical concepts and practical skills. Designed for developers and technology enthusiasts, the course requires basic programming knowledge and an interest in IoT technologies.`,
+  objectives: [
+    'Understand the fundamentals of IoT technology',
+    'Learn IoT device integration and interoperability',
+    'Build smart applications and systems',
+    'Explore IoT security and privacy considerations',
+  ],
+  modules: [
+    {
+      title: 'Module 1: Introduction to IoT',
+      lessons: [
+        'Lesson 1: Overview of Internet of Things',
+        'Lesson 2: History and Evolution of IoT',
+      ],
+    },
+    {
+      title: 'Module 2: IoT Devices and Protocols',
+      lessons: [
+        'Lesson 1: Basics of IoT Devices',
+        'Lesson 2: IoT Communication Protocols',
+      ],
+    },
+    {
+      title: 'Module 3: IoT Systems Development',
+      lessons: [
+        'Lesson 1: Designing IoT Systems',
+        'Lesson 2: Implementing IoT Solutions',
+      ],
+    },
+    {
+      title: 'Module 4: IoT Security and Privacy',
+      lessons: [
+        'Lesson 1: Securing IoT Systems',
+        'Lesson 2: Privacy Considerations in IoT',
+      ],
+    },
+  ],
+  projects: `Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your IoT development skills.`,
+  assessment: `The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in Internet of Things technology.`,
+  resources: `Access a list of recommended readings, tools, and forums to further your knowledge and connect with other IoT enthusiasts.`,
 };
+
+const IoTCourse = () => <CoursePageTemplate {...iotCourseData} />;
 
 export default IoTCourse;

--- a/src/pages/QuantumCourse.js
+++ b/src/pages/QuantumCourse.js
@@ -1,88 +1,51 @@
 import React from 'react';
-import '../styles/CoursePage.css';
+import CoursePageTemplate from '../components/CoursePageTemplate';
 
-const QuantumCourse = () => {
-  return (
-    <div className="course-page">
-      <h1>Quantum Quorist: Comprehensive Quantum Computing Course</h1>
-      
-      <section>
-        <h2>Course Title</h2>
-        <p>Comprehensive Quantum Computing Course</p>
-      </section>
-
-      <section>
-        <h2>Course Overview</h2>
-        <p>
-          This course provides an in-depth understanding of quantum mechanics and computing, focusing on both theoretical concepts and practical skills. 
-          Designed for scientists and technology enthusiasts, the course requires basic knowledge of physics and an interest in quantum technologies.
-        </p>
-      </section>
-
-      <section>
-        <h2>Learning Objectives</h2>
-        <ul>
-          <li>Understand the fundamentals of quantum mechanics</li>
-          <li>Learn quantum computing algorithms and architectures</li>
-          <li>Explore quantum cryptography and secure communications</li>
-          <li>Develop quantum simulations for scientific research</li>
-        </ul>
-      </section>
-
-      <section>
-        <h2>Modules and Lessons</h2>
-        <div className="module">
-          <h3>Module 1: Introduction to Quantum Mechanics</h3>
-          <ul>
-            <li>Lesson 1: Fundamentals of Quantum Mechanics</li>
-            <li>Lesson 2: Quantum States and Entanglement</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 2: Quantum Computing</h3>
-          <ul>
-            <li>Lesson 1: Basics of Quantum Computing</li>
-            <li>Lesson 2: Quantum Algorithms</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 3: Quantum Cryptography</h3>
-          <ul>
-            <li>Lesson 1: Principles of Quantum Cryptography</li>
-            <li>Lesson 2: Quantum Key Distribution</li>
-          </ul>
-        </div>
-        <div className="module">
-          <h3>Module 4: Quantum Simulations</h3>
-          <ul>
-            <li>Lesson 1: Designing Quantum Simulations</li>
-            <li>Lesson 2: Applications of Quantum Simulations</li>
-          </ul>
-        </div>
-      </section>
-
-      <section>
-        <h2>Hands-On Projects</h2>
-        <p>
-          Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your quantum computing skills.
-        </p>
-      </section>
-
-      <section>
-        <h2>Assessment and Certification</h2>
-        <p>
-          The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in quantum computing.
-        </p>
-      </section>
-
-      <section>
-        <h2>Additional Resources</h2>
-        <p>
-          Access a list of recommended readings, tools, and forums to further your knowledge and connect with other quantum computing enthusiasts.
-        </p>
-      </section>
-    </div>
-  );
+const quantumCourseData = {
+  title: 'Quantum Quorist: Comprehensive Quantum Computing Course',
+  courseTitle: 'Comprehensive Quantum Computing Course',
+  overview: `This course provides an in-depth understanding of quantum mechanics and computing, focusing on both theoretical concepts and practical skills. Designed for scientists and technology enthusiasts, the course requires basic knowledge of physics and an interest in quantum technologies.`,
+  objectives: [
+    'Understand the fundamentals of quantum mechanics',
+    'Learn quantum computing algorithms and architectures',
+    'Explore quantum cryptography and secure communications',
+    'Develop quantum simulations for scientific research',
+  ],
+  modules: [
+    {
+      title: 'Module 1: Introduction to Quantum Mechanics',
+      lessons: [
+        'Lesson 1: Fundamentals of Quantum Mechanics',
+        'Lesson 2: Quantum States and Entanglement',
+      ],
+    },
+    {
+      title: 'Module 2: Quantum Computing',
+      lessons: [
+        'Lesson 1: Basics of Quantum Computing',
+        'Lesson 2: Quantum Algorithms',
+      ],
+    },
+    {
+      title: 'Module 3: Quantum Cryptography',
+      lessons: [
+        'Lesson 1: Principles of Quantum Cryptography',
+        'Lesson 2: Quantum Key Distribution',
+      ],
+    },
+    {
+      title: 'Module 4: Quantum Simulations',
+      lessons: [
+        'Lesson 1: Designing Quantum Simulations',
+        'Lesson 2: Applications of Quantum Simulations',
+      ],
+    },
+  ],
+  projects: `Engage in real-world projects that allow you to apply the concepts learned throughout the course. These projects will help you build a portfolio of work that demonstrates your quantum computing skills.`,
+  assessment: `The course includes quizzes, assignments, and a final project to assess your understanding and skills. Upon successful completion, you will receive a certification that acknowledges your expertise in quantum computing.`,
+  resources: `Access a list of recommended readings, tools, and forums to further your knowledge and connect with other quantum computing enthusiasts.`,
 };
+
+const QuantumCourse = () => <CoursePageTemplate {...quantumCourseData} />;
 
 export default QuantumCourse;


### PR DESCRIPTION
## Summary
- add `CoursePageTemplate` component for consistent course layout
- refactor AI, Blockchain, IoT and Quantum course pages to provide structured curriculum data via the template

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6895534e618c832a8f29ff10401cce9a