### PR TITLE
Add Genesis Faction page and navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ const AIArchitect = lazy(() => import('./pages/AIArchitect'));
 const AICourse = lazy(() => import('./pages/AICourse'));
 const IoTInnovator = lazy(() => import('./pages/IoTInnovator'));
 const IoTCourse = lazy(() => import('./pages/IoTCourse'));
+const GenesisFaction = lazy(() => import('./pages/GenesisFaction'));
 const HouseOfCodeTasks = lazy(() => import('./pages/HouseOfCode/tasks'));
 const TaskManager = lazy(() => import('./sections/TaskManager'));
 const DocumentSubmission = lazy(() => import('./sections/DocumentSubmission'));
@@ -41,6 +42,7 @@ const App = () => {
                 <Route path="/ai-architect/course" element={<AICourse />} />
                 <Route path="/iot-innovator" element={<IoTInnovator />} />
                 <Route path="/iot-innovator/course" element={<IoTCourse />} />
+                <Route path="/genesis-faction" element={<GenesisFaction />} />
                 <Route path="/house-of-code/tasks" element={<HouseOfCodeTasks />} />
                 <Route path="/tasks" element={<TaskManager />} />
                 <Route path="/submit" element={<DocumentSubmission />} />

--- a/src/components/FeaturedFactions.js
+++ b/src/components/FeaturedFactions.js
@@ -22,11 +22,17 @@ const FeaturedFactions = () => {
       image: '/images/ai-architect.webp',
       link: '/ai-architect'
     },
-    { 
-      name: 'IoT Innovator', 
+    {
+      name: 'IoT Innovator',
       description: 'Pioneering innovations in Internet of Things (IoT) systems and enhancing IoT security.',
       image: '/images/iot-innovator.webp',
       link: '/iot-innovator'
+    },
+    {
+      name: 'Genesis Faction',
+      description: 'Establishing core principles and cross-domain collaboration for the metaverse.',
+      image: '/images/genesis-faction.webp',
+      link: '/genesis-faction'
     }
   ];
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -14,6 +14,7 @@ const Header = () => {
       <div className="logo">Metaverse-Platform</div>
       <nav className="nav">
         <Link to="/">Home</Link>
+        <Link to="/genesis-faction">Genesis Faction</Link>
         <Link to="/submit">Submit Document</Link>
         <Link to="/feedback">Feedback</Link>
         <Link to="/governance">Governance</Link>

--- a/src/pages/GenesisFaction.js
+++ b/src/pages/GenesisFaction.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import FactionPageTemplate from '../components/FactionPageTemplate';
+
+const GenesisFaction = () => {
+  return (
+    <FactionPageTemplate
+      title="Genesis Faction"
+      description="The founding faction establishing core principles and cross-domain collaboration."
+      charter={(
+        <>
+          <p>
+            The Genesis Faction Charter lays the groundwork for a unified community that bridges innovations across
+            decentralized technologies. We operate with transparency, inclusivity, and a commitment to open-source
+            advancement as we shape the earliest standards for the metaverse.
+          </p>
+          <p>
+            Governance within Genesis is participatory and consensus-driven, empowering members to propose initiatives,
+            vote on priorities, and steward shared resources for the benefit of the broader ecosystem.
+          </p>
+        </>
+      )}
+      mission={(
+        <>
+          <p>
+            Our mission is to nurture a collaborative environment where pioneers from diverse technical backgrounds can
+            experiment, learn, and build together. By providing guidance and a shared repository of knowledge, Genesis
+            accelerates projects that push the boundaries of what interconnected digital worlds can become.
+          </p>
+          <p>
+            Through mentorship, community events, and cross-faction partnerships, we aspire to cultivate the next wave of
+            innovators who will define the metaverse era.
+          </p>
+        </>
+      )}
+      focus={(
+        <>
+          <p>Our focus areas include:</p>
+          <ul>
+            <li>Creating foundational protocols for interoperability between emerging factions</li>
+            <li>Documenting best practices around decentralized governance and collaboration</li>
+            <li>Hosting hackathons and workshops to incubate new cross-domain projects</li>
+            <li>Supporting ethical guidelines and sustainable growth of the metaverse</li>
+          </ul>
+          <p>
+            By concentrating on these pillars, the Genesis Faction serves as the launchpad for initiatives that will
+            influence every corner of the platform.
+          </p>
+        </>
+      )}
+    />
+  );
+};
+
+export default GenesisFaction;


### PR DESCRIPTION
## Summary
- add Genesis Faction landing page using FactionPageTemplate
- wire up `/genesis-faction` route with lazy loading
- expose Genesis Faction in header and featured factions navigation

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68955732fd34832abe28c041a2247ec7