### PR TITLE
feat: add loading and retry for task suggestions

### DIFF
--- a/src/components/shared/AlertMessage.tsx
+++ b/src/components/shared/AlertMessage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface AlertMessageProps {
+  type?: 'error' | 'info' | 'success' | 'warning';
+  message: string;
+  onRetry?: () => void;
+}
+
+const typeStyles: Record<string, string> = {
+  error: 'bg-red-100 text-red-700',
+  info: 'bg-blue-100 text-blue-700',
+  success: 'bg-green-100 text-green-700',
+  warning: 'bg-yellow-100 text-yellow-700',
+};
+
+const AlertMessage: React.FC<AlertMessageProps> = ({ type = 'info', message, onRetry }) => (
+  <div className={`p-4 mb-4 rounded ${typeStyles[type]} flex items-center justify-between`} role="alert">
+    <span>{message}</span>
+    {onRetry && (
+      <button
+        onClick={onRetry}
+        className="ml-4 px-3 py-1 rounded bg-white text-sm border border-current"
+      >
+        Retry
+      </button>
+    )}
+  </div>
+);
+
+export default AlertMessage;

--- a/src/pages/HouseOfCode/tasks.tsx
+++ b/src/pages/HouseOfCode/tasks.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import useMpns from '../../hooks/useMpns';
 import useGptRecommendation from '../../hooks/useGptRecommendation';
+import LoadingSpinner from '../../components/shared/LoadingSpinner';
+import AlertMessage from '../../components/shared/AlertMessage';
 
 interface Task {
   title?: string;
@@ -8,43 +10,77 @@ interface Task {
 }
 
 const HouseOfCodeTasks: React.FC = () => {
-  const { result } = useMpns('houseOfCode.tasks.level1.mpns');
+  const { result, status: mpnsStatus, resolve } = useMpns(
+    'houseOfCode.tasks.level1.mpns',
+  );
   const [tasks, setTasks] = useState<Task[]>([]);
-  const { suggestions, status: suggestionStatus } = useGptRecommendation(
+  const [tasksStatus, setTasksStatus] = useState<
+    'idle' | 'loading' | 'ready' | 'error'
+  >('idle');
+  const [tasksError, setTasksError] = useState('');
+  const { suggestions, status: suggestionStatus, refresh } = useGptRecommendation(
     'houseOfCode.rules.mpns',
     'user.level.mpns',
   );
 
-  useEffect(() => {
-    const load = async () => {
-      if (result.type === 'ipfs' && result.value) {
-        let url = result.value;
-        if (url.startsWith('ipfs://')) {
-          url = `https://ipfs.io/ipfs/${url.slice(7)}`;
-        }
-        try {
-          const resp = await fetch(url);
-          const data = await resp.json();
-          if (Array.isArray(data)) {
-            setTasks(data);
-          } else if (Array.isArray(data.tasks)) {
-            setTasks(data.tasks);
-          }
-        } catch (err) {
-          console.error('Failed to load tasks', err);
-        }
+  const loadTasks = async () => {
+    if (result.type === 'ipfs' && result.value) {
+      let url = result.value;
+      if (url.startsWith('ipfs://')) {
+        url = `https://ipfs.io/ipfs/${url.slice(7)}`;
       }
-    };
-    load();
+      setTasksStatus('loading');
+      setTasksError('');
+      try {
+        const resp = await fetch(url);
+        const data = await resp.json();
+        if (Array.isArray(data)) {
+          setTasks(data);
+        } else if (Array.isArray(data.tasks)) {
+          setTasks(data.tasks);
+        } else {
+          setTasks([]);
+        }
+        setTasksStatus('ready');
+      } catch (err) {
+        console.error('Failed to load tasks', err);
+        setTasksStatus('error');
+        setTasksError('Failed to load tasks.');
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (result.type === 'ipfs') {
+      loadTasks();
+    }
   }, [result]);
 
   return (
     <div className="flex p-4">
       <div className="flex-1 pr-4">
         <h1 className="text-2xl font-bold mb-4">House of Code Tasks</h1>
-        {tasks.length === 0 ? (
+        {(mpnsStatus === 'loading' || tasksStatus === 'loading') && (
+          <LoadingSpinner size="md" text="Loading tasks..." />
+        )}
+        {mpnsStatus === 'error' && (
+          <AlertMessage
+            type="error"
+            message="Failed to resolve tasks location."
+            onRetry={() => resolve('houseOfCode.tasks.level1.mpns')}
+          />
+        )}
+        {tasksStatus === 'error' && (
+          <AlertMessage
+            type="error"
+            message={tasksError || 'Failed to load tasks.'}
+            onRetry={loadTasks}
+          />
+        )}
+        {tasksStatus === 'ready' && tasks.length === 0 && (
           <div>No tasks found.</div>
-        ) : (
+        )}
+        {tasksStatus === 'ready' && tasks.length > 0 && (
           <ul className="list-disc pl-5 space-y-2">
             {tasks.map((task, idx) => (
               <li key={idx}>{task.title || `Task ${idx + 1}`}</li>
@@ -54,8 +90,16 @@ const HouseOfCodeTasks: React.FC = () => {
       </div>
       <aside className="w-64 border-l pl-4">
         <h2 className="text-xl font-bold mb-2">AI Suggestions</h2>
-        {suggestionStatus === 'loading' && <div>Loading suggestions...</div>}
-        {suggestionStatus === 'error' && <div>Failed to load suggestions.</div>}
+        {suggestionStatus === 'loading' && (
+          <LoadingSpinner size="sm" text="Loading suggestions..." />
+        )}
+        {suggestionStatus === 'error' && (
+          <AlertMessage
+            type="error"
+            message="Failed to load suggestions."
+            onRetry={refresh}
+          />
+        )}
         {suggestionStatus === 'ready' && suggestions.length === 0 && (
           <div>No suggestions available.</div>
         )}


### PR DESCRIPTION
## Summary
- show loading spinners for MpNS resolution and GPT suggestions
- display styled alerts with retry buttons on fetch errors
- add reusable `AlertMessage` component and refresh logic

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68955b86cf08832ab1cbe4420143f1e9