### PR TITLE
Use MpNS resolution across services and add tests

### DIFF
--- a/contracts/test/mpns/registry.test.ts
+++ b/contracts/test/mpns/registry.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
+
+describe('MpNSRegistry - mpns', function () {
+  async function deploy() {
+    const [deployer, registrar, user] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory('MpNSRegistry');
+    const registry = await upgrades.deployProxy(Registry, { initializer: 'initialize' });
+    await registry.waitForDeployment();
+    await registry.grantRole(await registry.REGISTRAR_ROLE(), registrar.address);
+    return { registry, registrar, user };
+  }
+
+  it('registers a name', async function () {
+    const { registry, registrar, user } = await deploy();
+    const duration = 60 * 60 * 24;
+    await expect(
+      registry.connect(registrar).register('alice', user.address, duration, 'ipfs://old')
+    ).to.emit(registry, 'NameRegistered').withArgs('alice', user.address, anyValue, 'ipfs://old');
+    expect(await registry.ownerOf('alice')).to.equal(user.address);
+  });
+
+  it('updates a URI', async function () {
+    const { registry, registrar, user } = await deploy();
+    const duration = 60 * 60 * 24;
+    await registry.connect(registrar).register('alice', user.address, duration, 'ipfs://old');
+    await expect(
+      registry.connect(user).updateURI('alice', 'ipfs://new')
+    ).to.emit(registry, 'URIUpdated').withArgs('alice', 'ipfs://old', 'ipfs://new');
+    expect(await registry.nameToUri('alice')).to.equal('ipfs://new');
+  });
+
+  it('resolves a registered name', async function () {
+    const { registry, registrar, user } = await deploy();
+    const duration = 60 * 60 * 24;
+    await registry.connect(registrar).register('alice', user.address, duration, 'ipfs://old');
+    expect(await registry.nameToUri('alice')).to.equal('ipfs://old');
+  });
+});

--- a/docs/FACTIONS.md
+++ b/docs/FACTIONS.md
@@ -1,0 +1,18 @@
+---
+title: Factions
+sidebar_position: 5
+---
+
+# Factions
+
+Example usage of MpNS records for faction content:
+
+```tsx
+import FactionContentList from '../src/components/factions/FactionContentList';
+
+export const Tasks = () => (
+  <FactionContentList mpnsName="ai-architect.tasks.mpns" title="AI Architect Tasks" />
+);
+```
+
+The `mpnsName` value is resolved at runtime via `useMpns`, allowing faction pages to reference content by name rather than hardcoding IPFS hashes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,3 +52,16 @@ Registering names requires the `REGISTRAR_ROLE`. Roles can only be granted by an
 2. Call `register(name, owner, duration, uri)` on `MpNSRegistry`.
 3. The owner can later `updateURI`, `transfer`, or `freezeName` as needed.
 
+### Resolving Names in React
+
+Fetch contract addresses or IPFS content by name using the `useMpns` hook:
+
+```tsx
+import useMpns from '../src/hooks/useMpns';
+
+const Example: React.FC = () => {
+  const { result } = useMpns('ai-architect');
+  return <span>{result.value}</span>;
+};
+```
+

--- a/src/hooks/__tests__/useMpns.test.ts
+++ b/src/hooks/__tests__/useMpns.test.ts
@@ -1,0 +1,17 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useMpns from '../useMpns';
+
+describe('useMpns hook', () => {
+  it('resolves a local ipfs record', async () => {
+    const { result } = renderHook(() => useMpns('ai-architect'));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.result.type).toBe('ipfs');
+    expect(result.current.result.value).toContain('ipfs://');
+  });
+
+  it('returns empty for unknown name', async () => {
+    const { result } = renderHook(() => useMpns('unknown-name'));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.result.type).toBe('empty');
+  });
+});

--- a/src/services/eventListeners.ts
+++ b/src/services/eventListeners.ts
@@ -12,6 +12,7 @@ import {
   GenesisBlockFactory,
 } from '../contracts';
 import { getProvider } from './provider';
+import { resolveMpnsName } from '../hooks/useMpns';
 import {
   addGovernanceTokenEvent,
   addFunctionalTokenEvent,
@@ -58,67 +59,56 @@ const attachListeners = (
   });
 };
 
-export const initEventListeners = (dispatch: Dispatch) => {
+export const initEventListeners = async (dispatch: Dispatch) => {
   const provider = getProvider();
 
+  const getAddress = async (mpns: string, envKey: string) => {
+    const env =
+      process.env[`REACT_APP_${envKey}_ADDRESS`] ||
+      process.env[`${envKey}_ADDRESS`];
+    if (env) return env;
+    const res = await resolveMpnsName(mpns, provider);
+    return res.value || '0x0000000000000000000000000000000000000000';
+  };
+
   const governanceToken = new GovernanceToken(
-    process.env.REACT_APP_GOVERNANCE_TOKEN_ADDRESS ||
-      process.env.GOVERNANCE_TOKEN_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('governance-token.mpns', 'GOVERNANCE_TOKEN'),
     provider,
   );
   const functionalToken = new FunctionalToken(
-    process.env.REACT_APP_FUNCTIONAL_TOKEN_ADDRESS ||
-      process.env.FUNCTIONAL_TOKEN_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('functional-token.mpns', 'FUNCTIONAL_TOKEN'),
     provider,
   );
   const mpnsRegistry = new MpNSRegistry(
-    process.env.REACT_APP_MPNS_REGISTRY_ADDRESS ||
-      process.env.MPNS_REGISTRY_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('mpns-registry.mpns', 'MPNS_REGISTRY'),
     provider,
   );
   const crossFactionHub = new CrossFactionHub(
-    process.env.REACT_APP_CROSS_FACTION_HUB_ADDRESS ||
-      process.env.CROSS_FACTION_HUB_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('cross-faction-hub.mpns', 'CROSS_FACTION_HUB'),
     provider,
   );
   const gtStaking = new GTStaking(
-    process.env.REACT_APP_GT_STAKING_ADDRESS ||
-      process.env.GT_STAKING_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('gt-staking.mpns', 'GT_STAKING'),
     provider,
   );
   const houseOfTheLaw = new HouseOfTheLaw(
-    process.env.REACT_APP_HOUSE_OF_THE_LAW_ADDRESS ||
-      process.env.HOUSE_OF_THE_LAW_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('house-of-the-law.mpns', 'HOUSE_OF_THE_LAW'),
     provider,
   );
   const proofOfObservation = new ProofOfObservation(
-    process.env.REACT_APP_PROOF_OF_OBSERVATION_ADDRESS ||
-      process.env.PROOF_OF_OBSERVATION_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('proof-of-observation.mpns', 'PROOF_OF_OBSERVATION'),
     provider,
   );
   const pooTaskFlow = new PoO_TaskFlow(
-    process.env.REACT_APP_POO_TASK_FLOW_ADDRESS ||
-      process.env.POO_TASK_FLOW_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('poo-task-flow.mpns', 'POO_TASK_FLOW'),
     provider,
   );
   const genesisBlockFaction = new GenesisBlockFaction(
-    process.env.REACT_APP_GENESIS_BLOCK_FACTION_ADDRESS ||
-      process.env.GENESIS_BLOCK_FACTION_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('genesis-block-faction.mpns', 'GENESIS_BLOCK_FACTION'),
     provider,
   );
   const genesisBlockFactory = new GenesisBlockFactory(
-    process.env.REACT_APP_GENESIS_BLOCK_FACTORY_ADDRESS ||
-      process.env.GENESIS_BLOCK_FACTORY_ADDRESS ||
-      '0x0000000000000000000000000000000000000000',
+    await getAddress('genesis-block-factory.mpns', 'GENESIS_BLOCK_FACTORY'),
     provider,
   );
 

--- a/src/services/gtService.ts
+++ b/src/services/gtService.ts
@@ -1,5 +1,6 @@
 import { GovernanceToken, GTStaking } from '../contracts';
 import { getProvider, getSigner } from './provider';
+import { resolveMpnsName } from '../hooks/useMpns';
 
 export interface StakeParams {
   id: number;
@@ -17,20 +18,12 @@ export interface GTService {
 let governanceToken: GovernanceToken | undefined;
 let stakingInstance: GTStaking | undefined;
 
-const GOVERNANCE_TOKEN_ADDRESS =
-  process.env.REACT_APP_GOVERNANCE_TOKEN_ADDRESS ||
-  process.env.GOVERNANCE_TOKEN_ADDRESS ||
-  '0x0000000000000000000000000000000000000000';
-
-const GT_STAKING_ADDRESS =
-  process.env.REACT_APP_GT_STAKING_ADDRESS ||
-  process.env.GT_STAKING_ADDRESS ||
-  '0x0000000000000000000000000000000000000000';
-
 export const getGovernanceToken = async (): Promise<GovernanceToken> => {
   if (!governanceToken) {
     const provider = getProvider();
-    governanceToken = new GovernanceToken(GOVERNANCE_TOKEN_ADDRESS, provider);
+    const res = await resolveMpnsName('governance-token.mpns', provider);
+    const address = res.value || '0x0000000000000000000000000000000000000000';
+    governanceToken = new GovernanceToken(address, provider);
   }
   return governanceToken;
 };
@@ -38,7 +31,9 @@ export const getGovernanceToken = async (): Promise<GovernanceToken> => {
 export const getGTStaking = async (): Promise<GTStaking> => {
   if (!stakingInstance) {
     const provider = getProvider();
-    stakingInstance = new GTStaking(GT_STAKING_ADDRESS, provider);
+    const res = await resolveMpnsName('gt-staking.mpns', provider);
+    const address = res.value || '0x0000000000000000000000000000000000000000';
+    stakingInstance = new GTStaking(address, provider);
   }
   return stakingInstance;
 };

--- a/src/services/houseOfTheLawService.ts
+++ b/src/services/houseOfTheLawService.ts
@@ -1,5 +1,6 @@
 import { HouseOfTheLaw } from '../contracts';
 import { getProvider, getSigner } from './provider';
+import { resolveMpnsName } from '../hooks/useMpns';
 
 export interface ProposalParams {
   description: string;
@@ -30,15 +31,12 @@ export interface HouseOfTheLawService {
 
 let houseInstance: HouseOfTheLaw | undefined;
 
-const HOTL_ADDRESS =
-  process.env.REACT_APP_HOUSE_OF_THE_LAW_ADDRESS ||
-  process.env.HOUSE_OF_THE_LAW_ADDRESS ||
-  '0x0000000000000000000000000000000000000000';
-
 export const getHouse = async (): Promise<HouseOfTheLaw> => {
   if (!houseInstance) {
     const provider = getProvider();
-    houseInstance = new HouseOfTheLaw(HOTL_ADDRESS, provider);
+    const res = await resolveMpnsName('house-of-the-law.mpns', provider);
+    const address = res.value || '0x0000000000000000000000000000000000000000';
+    houseInstance = new HouseOfTheLaw(address, provider);
   }
   return houseInstance;
 };

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -1,6 +1,7 @@
 import { GTStaking } from '../contracts';
 import { getProvider } from './provider';
 import type { TaskMetrics } from '../contracts/types';
+import { resolveMpnsName } from '../hooks/useMpns';
 
 export interface TaskService {
   getGTStaking(): Promise<GTStaking>;
@@ -10,15 +11,12 @@ export interface TaskService {
 let stakingInstance: GTStaking | undefined;
 const metricsCache = new Map<number, TaskMetrics>();
 
-const GT_STAKING_ADDRESS =
-  process.env.REACT_APP_GT_STAKING_ADDRESS ||
-  process.env.GT_STAKING_ADDRESS ||
-  '0x0000000000000000000000000000000000000000';
-
 export const getGTStaking = async (): Promise<GTStaking> => {
   if (!stakingInstance) {
     const provider = getProvider();
-    stakingInstance = new GTStaking(GT_STAKING_ADDRESS, provider);
+    const res = await resolveMpnsName('gt-staking.mpns', provider);
+    const address = res.value || '0x0000000000000000000000000000000000000000';
+    stakingInstance = new GTStaking(address, provider);
   }
   return stakingInstance;
 };


### PR DESCRIPTION
## Summary
- Add standalone `resolveMpnsName` helper and refactor services and event listeners to use MpNS instead of static addresses
- Add Hardhat tests for MpNS registration, update, and resolution
- Create React hook tests for `useMpns` and document usage examples

## Testing
- `npx hardhat test test/mpns/registry.test.ts` *(fails: Couldn't download compiler version list)*
- `CI=true npm test -- src/hooks/__tests__/useMpns.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689568613600832aa44483be5515f244