### PR TITLE
Add contract-based access control middleware

### DIFF
--- a/src/store/__tests__/accessControlMiddleware.test.js
+++ b/src/store/__tests__/accessControlMiddleware.test.js
@@ -1,0 +1,66 @@
+import accessControlMiddleware from '../accessControlMiddleware';
+import { resolveMpnsName } from '../../hooks/useMpns';
+import { getProvider } from '../../services/provider';
+import { ethers, BigNumber } from 'ethers';
+
+jest.mock('../../hooks/useMpns', () => ({
+  resolveMpnsName: jest.fn(),
+}));
+
+jest.mock('../../services/provider', () => ({
+  getProvider: jest.fn(),
+}));
+
+jest.mock('ethers', () => {
+  const actual = jest.requireActual('ethers');
+  return {
+    ethers: { ...actual.ethers, Contract: jest.fn() },
+    BigNumber: actual.BigNumber,
+  };
+});
+
+describe('accessControlMiddleware', () => {
+  const address = '0xabc';
+  const action = { type: 'navigation/attempt' };
+  let store;
+  let next;
+
+  beforeEach(() => {
+    store = { getState: () => ({ wallet: { address } }), dispatch: jest.fn() };
+    next = jest.fn();
+    getProvider.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows action when balance and role are valid', async () => {
+    resolveMpnsName
+      .mockResolvedValueOnce({ type: 'contract', value: '0x1' })
+      .mockResolvedValueOnce({ type: 'contract', value: '0x2' });
+
+    ethers.Contract
+      .mockImplementationOnce(() => ({ balanceOf: jest.fn().mockResolvedValue(BigNumber.from(1)) }))
+      .mockImplementationOnce(() => ({ hasRole: jest.fn().mockResolvedValue(true) }));
+
+    await accessControlMiddleware(store)(next)(action);
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('blocks action and logs error when requirements fail', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    resolveMpnsName
+      .mockResolvedValueOnce({ type: 'contract', value: '0x1' })
+      .mockResolvedValueOnce({ type: 'contract', value: '0x2' });
+
+    ethers.Contract
+      .mockImplementationOnce(() => ({ balanceOf: jest.fn().mockResolvedValue(BigNumber.from(0)) }))
+      .mockImplementationOnce(() => ({ hasRole: jest.fn().mockResolvedValue(false) }));
+
+    await accessControlMiddleware(store)(next)(action);
+    expect(next).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/store/accessControlMiddleware.js
+++ b/src/store/accessControlMiddleware.js
@@ -1,0 +1,47 @@
+import { ethers } from 'ethers';
+import { getProvider } from '../services/provider';
+import { resolveMpnsName } from '../hooks/useMpns';
+
+const checkedTypes = ['navigation/attempt', 'task/start', 'proposal/submit'];
+
+const accessControlMiddleware = (store) => (next) => async (action) => {
+  if (checkedTypes.includes(action.type)) {
+    const address = store.getState().wallet?.address;
+    try {
+      const provider = getProvider();
+      const [tokenRes, roleRes] = await Promise.all([
+        resolveMpnsName('houseOfCode.token.governance.mpns', provider),
+        resolveMpnsName('user.role.mpns', provider),
+      ]);
+      if (tokenRes.type !== 'contract' || roleRes.type !== 'contract') {
+        console.error('Required contracts unavailable');
+        return;
+      }
+      const token = new ethers.Contract(
+        tokenRes.value,
+        ['function balanceOf(address owner) view returns (uint256)'],
+        provider,
+      );
+      const roles = new ethers.Contract(
+        roleRes.value,
+        ['function hasRole(address account) view returns (bool)'],
+        provider,
+      );
+      const [balance, hasRole] = await Promise.all([
+        token.balanceOf(address),
+        roles.hasRole(address),
+      ]);
+      if (balance.gt(0) && hasRole) {
+        return next(action);
+      }
+      console.error('Access requirements not met');
+      return;
+    } catch (err) {
+      console.error('Access check failed', err);
+      return;
+    }
+  }
+  return next(action);
+};
+
+export default accessControlMiddleware;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import taskReducer from './taskSlice';
 import aiReducer from './aiSlice';
 import walletReducer from './walletSlice';
 import aiMiddleware from './aiMiddleware';
+import accessControlMiddleware from './accessControlMiddleware';
 import {
   governanceTokenEventsReducer,
   functionalTokenEventsReducer,
@@ -35,5 +36,5 @@ export const store = configureStore({
     genesisBlockFactoryEvents: genesisBlockFactoryEventsReducer,
   },
   middleware: (getDefault) =>
-    getDefault().concat(aiMiddleware),
+    getDefault().concat(aiMiddleware, accessControlMiddleware),
 });


### PR DESCRIPTION
## Summary
- add middleware that resolves MpNS names and validates token balance and role before allowing navigation, task, or proposal actions
- wire middleware into the Redux store
- cover authorized and unauthorized paths with unit tests

## Testing
- `CI=true npm test -- src/store/__tests__/accessControlMiddleware.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68956b02af84832ab98656599b9ffb2a