### PR TITLE
test: add faction hooks and pages tests

### DIFF
--- a/src/hooks/__tests__/useFactionDeploy.test.ts
+++ b/src/hooks/__tests__/useFactionDeploy.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import useFactionDeploy from '../useFactionDeploy';
+
+jest.mock('../../services/ipfsService', () => ({
+  __esModule: true,
+  default: { uploadAgentMd: jest.fn() },
+}));
+import ipfsService from '../../services/ipfsService';
+const mockUpload = ipfsService.uploadAgentMd as jest.Mock;
+
+const mockCreateFaction = jest.fn();
+const mockRegister = jest.fn();
+
+const mockUseContract = jest.fn();
+jest.mock('../useContract', () => ({
+  __esModule: true,
+  default: (name: string) => mockUseContract(name),
+}));
+
+describe('useFactionDeploy', () => {
+  beforeEach(() => {
+    mockUpload.mockReset();
+    mockCreateFaction.mockReset();
+    mockRegister.mockReset();
+    mockUseContract.mockReset();
+  });
+
+  it('deploys faction and registers charter', async () => {
+    mockUpload.mockResolvedValue('cid123');
+    mockCreateFaction.mockResolvedValue({
+      wait: () => Promise.resolve({ events: [{ args: { faction: '0xF' } }] }),
+    });
+    mockRegister.mockResolvedValue(undefined);
+    mockUseContract.mockImplementation((name) => async () => {
+      if (name === 'GenesisBlockFactory') {
+        return { createFaction: mockCreateFaction } as any;
+      }
+      if (name === 'FactionCharterRegistry') {
+        return { registerCharter: mockRegister } as any;
+      }
+      return {} as any;
+    });
+
+    const { result } = renderHook(() => useFactionDeploy('0xAccount'));
+    await act(async () => {
+      await result.current.deployFaction('AI', 'AGENTS', true);
+    });
+
+    expect(mockUpload).toHaveBeenCalledWith('AGENTS');
+    expect(mockCreateFaction).toHaveBeenCalledWith('AI');
+    expect(mockRegister).toHaveBeenCalledWith('0xF', 'AI', 'cid123', true);
+    expect(result.current.factionAddress).toBe('0xF');
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useFactionMetadata.test.ts
+++ b/src/hooks/__tests__/useFactionMetadata.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useFactionMetadata from '../useFactionMetadata';
+
+const mockResolve = jest.fn();
+
+jest.mock('../useMpns', () => ({
+  __esModule: true,
+  default: () => ({ resolve: mockResolve }),
+}));
+
+describe('useFactionMetadata', () => {
+  beforeEach(() => {
+    mockResolve.mockReset();
+    (global as any).fetch = jest.fn();
+  });
+
+  it('fetches and returns faction metadata', async () => {
+    const metadata = { title: 'AI Architect', description: 'Building futures' };
+    mockResolve.mockResolvedValue({ type: 'ipfs', value: 'ipfs://cid/metadata.json' });
+    (global as any).fetch.mockResolvedValue({
+      json: () => Promise.resolve(metadata),
+    });
+
+    const { result } = renderHook(() => useFactionMetadata('ai-architect'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(metadata);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns null for non-ipfs result', async () => {
+    mockResolve.mockResolvedValue({ type: 'empty' });
+    const { result } = renderHook(() => useFactionMetadata('unknown'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useGtValidation.test.ts
+++ b/src/hooks/__tests__/useGtValidation.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useGtValidation from '../useGtValidation';
+
+const mockUseSelector = jest.fn();
+const mockResult = { type: 'contract', value: '0xToken' };
+
+jest.mock('react-redux', () => ({
+  useSelector: (fn: any) => mockUseSelector(fn),
+}));
+
+jest.mock('../useMpns', () => ({
+  __esModule: true,
+  default: () => ({ result: mockResult }),
+}));
+
+const bigNumber = (v: any) => ({ value: BigInt(v), gte: (o: any) => BigInt(v) >= BigInt(o.value) });
+
+jest.mock('ethers', () => {
+  const mockBalanceOf = jest.fn();
+  class MockContract {
+    balanceOf = mockBalanceOf;
+  }
+  return {
+    __esModule: true,
+    ethers: {
+      Contract: MockContract,
+      BigNumber: { from: bigNumber },
+    },
+    mockBalanceOf,
+  };
+});
+
+jest.mock('../../services/provider', () => ({ getProvider: jest.fn() }));
+
+const { mockBalanceOf } = require('ethers');
+
+describe('useGtValidation', () => {
+  beforeEach(() => {
+    mockBalanceOf.mockReset();
+    mockUseSelector.mockReset();
+  });
+
+  it('returns true when balance meets requirement', async () => {
+    mockBalanceOf.mockResolvedValue(bigNumber(10));
+    mockUseSelector.mockImplementation((selector: any) => selector({ wallet: { address: '0x1' } }));
+    const { result } = renderHook(() => useGtValidation(5));
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('returns false without wallet address', async () => {
+    mockBalanceOf.mockResolvedValue(bigNumber(0));
+    mockUseSelector.mockImplementation((selector: any) => selector({ wallet: { address: null } }));
+    const { result } = renderHook(() => useGtValidation(5));
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});

--- a/src/pages/__tests__/faction-pages.test.tsx
+++ b/src/pages/__tests__/faction-pages.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import AIArchitect from '../AIArchitect';
+import BlockchainBattalion from '../BlockchainBattalion';
+import useFactionMetadata from '../../hooks/useFactionMetadata';
+
+jest.mock('../../hooks/useFactionMetadata');
+const mockUseFactionMetadata = useFactionMetadata as jest.Mock;
+
+describe('Faction pages', () => {
+  beforeEach(() => {
+    mockUseFactionMetadata.mockReset();
+  });
+
+  it('renders AI Architect metadata', () => {
+    mockUseFactionMetadata.mockReturnValue({
+      data: { title: 'AI Architect', description: 'Design AI systems' },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/ai-architect']}>
+        <Routes>
+          <Route path="/ai-architect" element={<AIArchitect />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /AI Architect/i })).toBeInTheDocument();
+    expect(screen.getByText(/Design AI systems/i)).toBeInTheDocument();
+  });
+
+  it('renders Blockchain Battalion metadata', () => {
+    mockUseFactionMetadata.mockReturnValue({
+      data: { title: 'Blockchain Battalion', description: 'Guardians of chains' },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/blockchain-battalion']}>
+        <Routes>
+          <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /Blockchain Battalion/i })).toBeInTheDocument();
+    expect(screen.getByText(/Guardians of chains/i)).toBeInTheDocument();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add unit tests for faction metadata, deployment, and governance token hooks
- test faction routes render expected metadata
- configure Jest with @testing-library/jest-dom setup

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895a16947b8832aa5e934e46caafbcf