### PR TITLE
Add shared FactionLayout and nest AI Architect routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import ErrorBoundary from './components/ErrorBoundary';
 import Loader from './components/Loader';
 import { ToastProvider } from './components/ToastProvider';
+import FactionLayout from './components/factions/FactionLayout';
 
 const Home = lazy(() => import('./pages/Home'));
 const QuantumQuorist = lazy(() => import('./pages/QuantumQuorist'));
@@ -58,46 +59,48 @@ const App = () => {
             <Suspense fallback={<Loader />}>
               <Routes>
                 <Route path="/" element={<Home />} />
-                  <Route path="/quantum-quorist" element={<QuantumQuorist />} />
-                  <Route path="/quantum-quorist/tasks" element={<QuantumQuoristTasks />} />
-                  <Route path="/quantum-quorist/proposals" element={<QuantumQuoristProposals />} />
-                  <Route path="/quantum-quorist/contributions" element={<QuantumQuoristContributions />} />
-                  <Route path="/quantum-quorist/governance" element={<QuantumQuoristGovernance />} />
-                  <Route path="/quantum-quorist/course" element={<QuantumCourse />} />
-                  <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
-                  <Route path="/blockchain-battalion/tasks" element={<BlockchainBattalionTasks />} />
-                  <Route path="/blockchain-battalion/proposals" element={<BlockchainBattalionProposals />} />
-                  <Route path="/blockchain-battalion/contributions" element={<BlockchainBattalionContributions />} />
-                  <Route path="/blockchain-battalion/governance" element={<BlockchainBattalionGovernance />} />
-                  <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} />
-                  <Route path="/ai-architect" element={<AIArchitect />} />
-                  <Route path="/ai-architect/tasks" element={<AIArchitectTasks />} />
-                  <Route path="/ai-architect/proposals" element={<AIArchitectProposals />} />
-                  <Route path="/ai-architect/contributions" element={<AIArchitectContributions />} />
-                  <Route path="/ai-architect/governance" element={<AIArchitectGovernance />} />
-                  <Route path="/ai-architect/course" element={<AICourse />} />
-                  <Route path="/iot-innovator" element={<IoTInnovator />} />
-                  <Route path="/iot-innovator/tasks" element={<IoTInnovatorTasks />} />
-                  <Route path="/iot-innovator/proposals" element={<IoTInnovatorProposals />} />
-                  <Route path="/iot-innovator/contributions" element={<IoTInnovatorContributions />} />
-                  <Route path="/iot-innovator/governance" element={<IoTInnovatorGovernance />} />
-                  <Route path="/iot-innovator/course" element={<IoTCourse />} />
-                  <Route path="/genesis-faction" element={<GenesisFaction />} />
-                  <Route path="/genesis-faction/tasks" element={<GenesisFactionTasks />} />
-                  <Route path="/genesis-faction/proposals" element={<GenesisFactionProposals />} />
-                  <Route path="/genesis-faction/contributions" element={<GenesisFactionContributions />} />
-                  <Route path="/genesis-faction/governance" element={<GenesisFactionGovernance />} />
-                  <Route path="/house-of-code" element={<HouseOfCode />} />
-                  <Route path="/house-of-code/tasks" element={<HouseOfCodeTasks />} />
-                  <Route path="/house-of-code/proposals" element={<HouseOfCodeProposals />} />
-                  <Route path="/house-of-code/contributions" element={<HouseOfCodeContributions />} />
-                  <Route path="/house-of-code/governance" element={<HouseOfCodeGovernance />} />
-                  <Route path="/tasks" element={<TaskManager />} />
-                  <Route path="/submit" element={<DocumentSubmission />} />
-                  <Route path="/feedback" element={<Feedback />} />
-                  <Route path="/governance" element={<Governance />} />
-                  <Route path="/task-builder" element={<TaskBuilder />} />
-                  <Route path="/projects" element={<ProjectManagement />} />
+                <Route path="/quantum-quorist" element={<QuantumQuorist />} />
+                <Route path="/quantum-quorist/tasks" element={<QuantumQuoristTasks />} />
+                <Route path="/quantum-quorist/proposals" element={<QuantumQuoristProposals />} />
+                <Route path="/quantum-quorist/contributions" element={<QuantumQuoristContributions />} />
+                <Route path="/quantum-quorist/governance" element={<QuantumQuoristGovernance />} />
+                <Route path="/quantum-quorist/course" element={<QuantumCourse />} />
+                <Route path="/blockchain-battalion" element={<BlockchainBattalion />} />
+                <Route path="/blockchain-battalion/tasks" element={<BlockchainBattalionTasks />} />
+                <Route path="/blockchain-battalion/proposals" element={<BlockchainBattalionProposals />} />
+                <Route path="/blockchain-battalion/contributions" element={<BlockchainBattalionContributions />} />
+                <Route path="/blockchain-battalion/governance" element={<BlockchainBattalionGovernance />} />
+                <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} />
+                <Route path="/ai-architect/*" element={<FactionLayout faction="ai-architect" />} >
+                  <Route index element={<AIArchitect />} />
+                  <Route path="tasks" element={<AIArchitectTasks />} />
+                  <Route path="proposals" element={<AIArchitectProposals />} />
+                  <Route path="contributions" element={<AIArchitectContributions />} />
+                  <Route path="governance" element={<AIArchitectGovernance />} />
+                  <Route path="course" element={<AICourse />} />
+                </Route>
+                <Route path="/iot-innovator" element={<IoTInnovator />} />
+                <Route path="/iot-innovator/tasks" element={<IoTInnovatorTasks />} />
+                <Route path="/iot-innovator/proposals" element={<IoTInnovatorProposals />} />
+                <Route path="/iot-innovator/contributions" element={<IoTInnovatorContributions />} />
+                <Route path="/iot-innovator/governance" element={<IoTInnovatorGovernance />} />
+                <Route path="/iot-innovator/course" element={<IoTCourse />} />
+                <Route path="/genesis-faction" element={<GenesisFaction />} />
+                <Route path="/genesis-faction/tasks" element={<GenesisFactionTasks />} />
+                <Route path="/genesis-faction/proposals" element={<GenesisFactionProposals />} />
+                <Route path="/genesis-faction/contributions" element={<GenesisFactionContributions />} />
+                <Route path="/genesis-faction/governance" element={<GenesisFactionGovernance />} />
+                <Route path="/house-of-code" element={<HouseOfCode />} />
+                <Route path="/house-of-code/tasks" element={<HouseOfCodeTasks />} />
+                <Route path="/house-of-code/proposals" element={<HouseOfCodeProposals />} />
+                <Route path="/house-of-code/contributions" element={<HouseOfCodeContributions />} />
+                <Route path="/house-of-code/governance" element={<HouseOfCodeGovernance />} />
+                <Route path="/tasks" element={<TaskManager />} />
+                <Route path="/submit" element={<DocumentSubmission />} />
+                <Route path="/feedback" element={<Feedback />} />
+                <Route path="/governance" element={<Governance />} />
+                <Route path="/task-builder" element={<TaskBuilder />} />
+                <Route path="/projects" element={<ProjectManagement />} />
               </Routes>
             </Suspense>
           </div>

--- a/src/components/factions/FactionLayout.tsx
+++ b/src/components/factions/FactionLayout.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+
+interface FactionLayoutProps {
+  faction: string;
+}
+
+const FactionLayout: React.FC<FactionLayoutProps> = ({ faction }) => {
+  const base = `/${faction}`;
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    isActive ? 'font-bold mr-4' : 'mr-4';
+
+  return (
+    <div className="p-4">
+      <nav className="mb-4">
+        <NavLink to={`${base}/tasks`} className={linkClass}>
+          Tasks
+        </NavLink>
+        <NavLink to={`${base}/proposals`} className={linkClass}>
+          Proposals
+        </NavLink>
+        <NavLink to={`${base}/contributions`} className={linkClass}>
+          Contributions
+        </NavLink>
+        <NavLink to={`${base}/governance`} className={linkClass}>
+          Governance
+        </NavLink>
+      </nav>
+      <Outlet />
+    </div>
+  );
+};
+
+export default FactionLayout;
+


### PR DESCRIPTION
## Summary
- add reusable `FactionLayout` component with faction navigation and `<Outlet />`
- nest `/ai-architect` routes under `FactionLayout` in `App.js`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895a9593a34832a96a6ed6b2d82d76d