### PR TITLE
feat: protect faction routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import Loader from './components/Loader';
 import { ToastProvider } from './components/ToastProvider';
 import FactionLayout from './components/factions/FactionLayout';
+import ProtectedFactionRoute from './routes/ProtectedFactionRoute';
 
 const Home = lazy(() => import('./pages/Home'));
 const QuantumQuorist = lazy(() => import('./pages/QuantumQuorist'));
@@ -41,6 +42,7 @@ const HouseOfCodeTasks = lazy(() => import('./pages/HouseOfCode/tasks'));
 const HouseOfCodeProposals = lazy(() => import('./pages/HouseOfCode/proposals'));
 const HouseOfCodeContributions = lazy(() => import('./pages/HouseOfCode/contributions'));
 const HouseOfCodeGovernance = lazy(() => import('./pages/HouseOfCode/governance'));
+const AccessDenied = lazy(() => import('./pages/AccessDenied'));
 const TaskManager = lazy(() => import('./sections/TaskManager'));
 const DocumentSubmission = lazy(() => import('./sections/DocumentSubmission'));
 const Feedback = lazy(() => import('./sections/Feedback'));
@@ -71,7 +73,14 @@ const App = () => {
                 <Route path="/blockchain-battalion/contributions" element={<BlockchainBattalionContributions />} />
                 <Route path="/blockchain-battalion/governance" element={<BlockchainBattalionGovernance />} />
                 <Route path="/blockchain-battalion/course" element={<BlockchainCourse />} />
-                <Route path="/ai-architect/*" element={<FactionLayout faction="ai-architect" />} >
+                <Route
+                  path="/ai-architect/*"
+                  element={
+                    <ProtectedFactionRoute requiredLevel={2} redirectPath="/access-denied">
+                      <FactionLayout faction="ai-architect" />
+                    </ProtectedFactionRoute>
+                  }
+                >
                   <Route index element={<AIArchitect />} />
                   <Route path="tasks" element={<AIArchitectTasks />} />
                   <Route path="proposals" element={<AIArchitectProposals />} />
@@ -101,6 +110,7 @@ const App = () => {
                 <Route path="/governance" element={<Governance />} />
                 <Route path="/task-builder" element={<TaskBuilder />} />
                 <Route path="/projects" element={<ProjectManagement />} />
+                <Route path="/access-denied" element={<AccessDenied />} />
               </Routes>
             </Suspense>
           </div>

--- a/src/pages/AccessDenied.tsx
+++ b/src/pages/AccessDenied.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const AccessDenied: React.FC = () => (
+  <div className="p-4">
+    <h2 className="text-2xl font-bold mb-2">Access Denied</h2>
+    <p className="mb-4">You do not meet the requirements to access this area.</p>
+    <Link to="/" className="text-blue-500 underline">
+      Return Home
+    </Link>
+  </div>
+);
+
+export default AccessDenied;

--- a/src/routes/ProtectedFactionRoute.tsx
+++ b/src/routes/ProtectedFactionRoute.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import useGtValidation from '../hooks/useGtValidation';
+
+interface ProtectedFactionRouteProps {
+  requiredLevel: number;
+  minGtBalance?: number | bigint;
+  redirectPath?: string;
+  children: React.ReactElement;
+}
+
+const ProtectedFactionRoute: React.FC<ProtectedFactionRouteProps> = ({
+  requiredLevel,
+  minGtBalance = 1,
+  redirectPath = '/',
+  children,
+}) => {
+  const { level, balance } = useSelector((state: any) => state.gt || {});
+  const hasChainBalance = useGtValidation(minGtBalance);
+
+  const meetsLevel = typeof level === 'number' && level >= requiredLevel;
+  const meetsBalance = typeof balance === 'number' && balance >= Number(minGtBalance);
+
+  if (!meetsLevel || !meetsBalance || !hasChainBalance) {
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedFactionRoute;


### PR DESCRIPTION
## Summary
- add ProtectedFactionRoute to gate faction access based on GT balance and level
- add AccessDenied page and wrap AI-Architect routes with new guard
- register access-denied route in App

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6895ab31f688832a80fa590c7f81fef9